### PR TITLE
Fixed paths; should be able to call script from anywhere

### DIFF
--- a/trafficcloud/app_config.py
+++ b/trafficcloud/app_config.py
@@ -19,7 +19,7 @@ class AppConfig(object):
     def load_application_config(cls):
         config_parser = SafeConfigParser()
         config_parser.read(os.path.join(os.path.dirname(os.path.realpath(__file__)), ".application"))
-        cls.PROJECT_DIR = config_parser.get("info", "default_project_dir")
+        cls.PROJECT_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), config_parser.get("info", "default_project_dir")))
         cls.TI_INSTALL_DIR = config_parser.get("info", "ti_install_dir")
 
     # TODO: class method for writing to application config file

--- a/trafficcloud/pm.py
+++ b/trafficcloud/pm.py
@@ -110,7 +110,7 @@ class ProjectWizard():
 
 
 def load_project(folder_path): # main_window):
-    path = os.path.normpath(folder_path)  # Clean path. May not be necessary.
+    path = os.path.join(ac.PROJECT_DIR, os.path.normpath(folder_path))  # Clean path. May not be necessary.
     project_name = os.path.basename(path)
     project_cfg = os.path.join(path, "{}.cfg".format(project_name))
     ac.CURRENT_PROJECT_PATH = path  # Set application-level variables indicating the currently open project


### PR DESCRIPTION
This change makes it so app_config gets the path as a relative location *of its own file* (that's what `__file__` does).  This means that you can call your script from everywhere, but app_config is always looking at the same place regardless of where you call the script from.