### PR TITLE
Fix upload; we're end-to-end!

### DIFF
--- a/app/handlers/upload.py
+++ b/app/handlers/upload.py
@@ -19,8 +19,7 @@ class UploadHandler(tornado.web.RequestHandler):
         name_body_dict = self.parse_request(self.request.files)
         project_identifier = api.saveFiles(name_body_dict)
 
-        # TODO(rlouie): This is the next step!!!
-        # api.runTrajectoryAnalysis(uuid)
+        api.runTrajectoryAnalysis(project_identifier)
 
         self.finish("Upload successful for project directory {}".format(project_identifier))
 

--- a/trafficcloud/api.py
+++ b/trafficcloud/api.py
@@ -11,7 +11,7 @@ import video, feat_config
 from plotting.make_object_trajectories import main as db_make_objtraj
 
 def saveFiles(diction, *args):
-    return str(pm.ProjectWizard(diction).identifier)
+    return pm.ProjectWizard(diction).identifier
 
 def runConfigTestFeature(identifier, config, frames, ret_type, ret_args, *args):
     ac.load_application_config()

--- a/trafficcloud/api.py
+++ b/trafficcloud/api.py
@@ -11,11 +11,9 @@ import video, feat_config
 from plotting.make_object_trajectories import main as db_make_objtraj
 
 def saveFiles(diction, *args):
-    pm.ProjectWizard(diction)
-    return pm.uuid
+    return str(pm.ProjectWizard(diction).identifier)
 
-
-def runConfigTestFeature(uuid, config, frames, ret_type, ret_args, *args):
+def runConfigTestFeature(identifier, config, frames, ret_type, ret_args, *args):
     ac.load_application_config()
     pm.load_project(ac.CURRENT_PROJECT_PATH)
 
@@ -38,12 +36,12 @@ def runConfigTestFeature(uuid, config, frames, ret_type, ret_args, *args):
 
     video.move_images_to_project_dir_folder(images_folder)
 
-def runTrajectoryAnalysis(uuid):#, config, ret_type, ret_args, *args):
+def runTrajectoryAnalysis(identifier):#, config, ret_type, ret_args, *args):
     """
     Runs TrafficIntelligence trackers and support scripts.
     """
     ac.load_application_config()
-    pm.load_project(uuid)
+    pm.load_project(identifier)
 
     # create test folder
     if not os.path.exists(ac.CURRENT_PROJECT_PATH + "/run"):
@@ -89,16 +87,16 @@ def runTrajectoryAnalysis(uuid):#, config, ret_type, ret_args, *args):
 
 
 
-def runSafetyAnalysis(uuid, prediction, db, ret_type, ret_args):
+def runSafetyAnalysis(identifier, prediction, db, ret_type, ret_args):
     pass
 
-def runVisualization(uuid, db, ret_form, ret_type, ret_args, *args):
+def runVisualization(identifier, db, ret_form, ret_type, ret_args, *args):
     pass
 
-def getDB(uuid):
+def getDB(identifier):
     pass
 
-def getStatus(uuid):
+def getStatus(identifier):
     pass
 
 def generateDefaultConfig():

--- a/trafficcloud/pm.py
+++ b/trafficcloud/pm.py
@@ -33,7 +33,7 @@ class ProjectWizard():
         ac.load_application_config()
         self.DEFAULT_PROJECT_DIR = ac.PROJECT_DIR
 
-        self.identifier = uuid.uuid4()
+        self.identifier = str(uuid.uuid4())
         self.config_parser = SafeConfigParser()
         self.create_project_dir(self.identifier)
 

--- a/trafficcloud/pm.py
+++ b/trafficcloud/pm.py
@@ -33,12 +33,12 @@ class ProjectWizard():
         ac.load_application_config()
         self.DEFAULT_PROJECT_DIR = ac.PROJECT_DIR
 
-        self.uuid = uuid.uuid4()
+        self.identifier = uuid.uuid4()
         self.config_parser = SafeConfigParser()
-        self.create_project_dir(self.uuid)
+        self.create_project_dir(self.identifier)
 
-    def create_project_dir(self, uuid):
-        self.project_name = str(uuid)
+    def create_project_dir(self, identifier):
+        self.project_name = str(identifier)
         directory_names = ["homography", ".temp/test/test_object/", ".temp/test/test_feature/", "run", "results"]
         pr_path = os.path.join(self.DEFAULT_PROJECT_DIR, self.project_name)
 


### PR DESCRIPTION
WE'RE END-TO-END! (Tested with `uploadfiles` branch of TrafficGUIs). 

This PR replaces `uuid` with `identifier` everywhere in order to avoid confusion between the module `uuid` and an instance of `uuid`. 

This PR also returns the identifier of the ProjectWizard, rather than accidentally returning the `pm` module's identifier (which doesn't exists). 