### PR TITLE
PDF generator for the report + requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+# The following packages are required, but the installation is separate from pip
+# cv2, cvutils (TrafficIntelligence), storage (TrafficIntelligence)
+matplotlib==1.3.1
+Image==1.5.5
+Pillow==4.0.0
+fpdf==1.7.2
+numpy==1.12.0
+scipy==0.18.1
+tornado==4.4.2

--- a/trafficcloud/pdf_generate.py
+++ b/trafficcloud/pdf_generate.py
@@ -1,0 +1,24 @@
+import os
+from fpdf import FPDF
+from PIL import Image
+
+def makePdf(pdfFileName, listImages, dir = ''):
+    """
+    Arguments
+    ---------
+    pdfFileName: str, i.e. 'output'
+    listImages: list of str, i.e. ['road_user_type_counts.png', 'speed_cdf.png']
+    dir: str, path where images located, and pdf will be outputted
+    """
+    cover = Image.open(os.path.join(dir, listImages[0]))
+    width, height = cover.size
+
+    pdf = FPDF(unit = "pt", format = [width, height])
+
+    # Save an image per page
+    for page in listImages:
+        pdf.add_page()
+        pdf.image(os.path.join(dir,str(page)), 0, 0)
+
+    pdf.output(os.path.join(dir, pdfFileName, ".pdf"), "F")
+

--- a/trafficcloud/pm.py
+++ b/trafficcloud/pm.py
@@ -7,7 +7,6 @@ from ConfigParser import SafeConfigParser, NoSectionError, NoOptionError
 import time
 import datetime
 from shutil import copy
-import cv2
 try:
     from PIL import Image
 except:


### PR DESCRIPTION
Summary:

- new method to generate PDFs from images, like saved graphs from matplotlib
- added a requirements.txt file, which installs fpdf package used for PDF generation
- removed extra 'import cv2' statement

Test:
tested the pdf generation statement
cv2 wasn't used in the pm.py file, so I assume the rest of pm.py would work