### PR TITLE
Config route

### DIFF
--- a/app/handlers/config.py
+++ b/app/handlers/config.py
@@ -2,21 +2,50 @@
 
 import tornado.web
 
+from trafficcloud.pm import default_config_dict, update_project_config
+
 class ConfigHandler(tornado.web.RequestHandler):
     """
-    @api {post} /config/ Configure Files
-    @apiName Configure Files
+    @api {post} /config/ Configure Project
+    @apiName Configure Project
     @apiVersion 0.0.0
     @apiGroup Configuration
-    @apiDescription Calling this route will modify a specified configuration file using specified key:value pairs. Provides a way to modify configuration files by changing variables rather than uploading complete files.
+    @apiDescription Calling this route will modify a specified configuration file using values of the provided arguments.
 
     @apiParam {String} identifier The identifier of the project whose configuration files are to be modified.
-    @apiParam {String} filename The name of the configuration file to be modified
-    @apiParam {Dictionary} config_data A dictionary of key:value pairs containing the configuration variables to be modified.
+    @apiParam {Integer} [max_features_per_frame] This is the maximum number of features to track per frame. If not provided, a value of 1000 will be used. The recommended value for this is 1000 or greater.
+    @apiParam {Integer} [num_displacement_frames] This parameter determines how long features will be tracked. If not provided, a value of 10 will be used. The recommended value for this is 2-15.
+    @apiParam {Number} [min_feature_displacement] This is the displacement needed to track a feature. If not provided, a value of 0.0001 will be used. The recommended value for this is 0.0001-0.1.
+    @apiParam {Integer} [max_iterations_to_persist] This is the maximum number of iterations that an unmoving feature should persist. If not provided, a value of 200 will be used. The recommended value for this is 10-1000.
+    @apiParam {Integer} [min_feature_frames] This is the minimum number of frames that a feature must persist in order to be considered a feature. If not provided, a value of 15 will be used. The recommended value for this is 10-25.
+    @apiParam {Number} [max_connection_distance] This is the maximum distance that two features can be apart and still be considered part of the same object. If not provided, a value of 1 will be used.
+    @apiParam {Number} [max_segmentation_distance] This is the maximum distance that two features that are moving relative to each other can be apart and still be considered part of the same object. If not provided, a value of .7 will be used.
+
 
     @apiSuccess status_code The API will return a status code of 200 upon success.
 
     @apiError error_message The error message to display.
     """
     def post(self):
+        identifier = self.get_body_argument("identifier")
+
+        config_keys = default_config_dict().keys()
+        config_dict = {}
+
+        for key in config_keys:
+            arg = self.get_body_argument(key, default=None)
+            if arg != None:
+                config_dict[key] = arg
+
+        self.handler(identifier, config_dict)
+
         self.finish("Config")
+
+    @staticmethod
+    def handler(identifier, config_dict):
+        update_project_config(identifier, config_dict)
+
+
+
+
+

--- a/app/static/apidoc/api_data.js
+++ b/app/static/apidoc/api_data.js
@@ -167,11 +167,11 @@ define({ "api": [
   {
     "type": "post",
     "url": "/config/",
-    "title": "Configure Files",
-    "name": "Configure_Files",
+    "title": "Configure Project",
+    "name": "Configure_Project",
     "version": "0.0.0",
     "group": "Configuration",
-    "description": "<p>Calling this route will modify a specified configuration file using specified key:value pairs. Provides a way to modify configuration files by changing variables rather than uploading complete files.</p>",
+    "description": "<p>Calling this route will modify a specified configuration file using values of the provided arguments.</p>",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -184,17 +184,52 @@ define({ "api": [
           },
           {
             "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "filename",
-            "description": "<p>The name of the configuration file to be modified</p>"
+            "type": "Integer",
+            "optional": true,
+            "field": "max_features_per_frame",
+            "description": "<p>This is the maximum number of features to track per frame. If not provided, a value of 1000 will be used. The recommended value for this is 1000 or greater.</p>"
           },
           {
             "group": "Parameter",
-            "type": "Dictionary",
-            "optional": false,
-            "field": "config_data",
-            "description": "<p>A dictionary of key:value pairs containing the configuration variables to be modified.</p>"
+            "type": "Integer",
+            "optional": true,
+            "field": "num_displacement_frames",
+            "description": "<p>This parameter determines how long features will be tracked. If not provided, a value of 10 will be used. The recommended value for this is 2-15.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Number",
+            "optional": true,
+            "field": "min_feature_displacement",
+            "description": "<p>This is the displacement needed to track a feature. If not provided, a value of 0.0001 will be used. The recommended value for this is 0.0001-0.1.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": true,
+            "field": "max_iterations_to_persist",
+            "description": "<p>This is the maximum number of iterations that an unmoving feature should persist. If not provided, a value of 200 will be used. The recommended value for this is 10-1000.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": true,
+            "field": "min_feature_frames",
+            "description": "<p>This is the minimum number of frames that a feature must persist in order to be considered a feature. If not provided, a value of 15 will be used. The recommended value for this is 10-25.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Number",
+            "optional": true,
+            "field": "max_connection_distance",
+            "description": "<p>This is the maximum distance that two features can be apart and still be considered part of the same object. If not provided, a value of 1 will be used.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Number",
+            "optional": true,
+            "field": "max_segmentation_distance",
+            "description": "<p>This is the maximum distance that two features that are moving relative to each other can be apart and still be considered part of the same object. If not provided, a value of .7 will be used.</p>"
           }
         ]
       }

--- a/app/static/apidoc/api_data.json
+++ b/app/static/apidoc/api_data.json
@@ -167,11 +167,11 @@
   {
     "type": "post",
     "url": "/config/",
-    "title": "Configure Files",
-    "name": "Configure_Files",
+    "title": "Configure Project",
+    "name": "Configure_Project",
     "version": "0.0.0",
     "group": "Configuration",
-    "description": "<p>Calling this route will modify a specified configuration file using specified key:value pairs. Provides a way to modify configuration files by changing variables rather than uploading complete files.</p>",
+    "description": "<p>Calling this route will modify a specified configuration file using values of the provided arguments.</p>",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -184,17 +184,52 @@
           },
           {
             "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "filename",
-            "description": "<p>The name of the configuration file to be modified</p>"
+            "type": "Integer",
+            "optional": true,
+            "field": "max_features_per_frame",
+            "description": "<p>This is the maximum number of features to track per frame. If not provided, a value of 1000 will be used. The recommended value for this is 1000 or greater.</p>"
           },
           {
             "group": "Parameter",
-            "type": "Dictionary",
-            "optional": false,
-            "field": "config_data",
-            "description": "<p>A dictionary of key:value pairs containing the configuration variables to be modified.</p>"
+            "type": "Integer",
+            "optional": true,
+            "field": "num_displacement_frames",
+            "description": "<p>This parameter determines how long features will be tracked. If not provided, a value of 10 will be used. The recommended value for this is 2-15.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Number",
+            "optional": true,
+            "field": "min_feature_displacement",
+            "description": "<p>This is the displacement needed to track a feature. If not provided, a value of 0.0001 will be used. The recommended value for this is 0.0001-0.1.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": true,
+            "field": "max_iterations_to_persist",
+            "description": "<p>This is the maximum number of iterations that an unmoving feature should persist. If not provided, a value of 200 will be used. The recommended value for this is 10-1000.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": true,
+            "field": "min_feature_frames",
+            "description": "<p>This is the minimum number of frames that a feature must persist in order to be considered a feature. If not provided, a value of 15 will be used. The recommended value for this is 10-25.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Number",
+            "optional": true,
+            "field": "max_connection_distance",
+            "description": "<p>This is the maximum distance that two features can be apart and still be considered part of the same object. If not provided, a value of 1 will be used.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Number",
+            "optional": true,
+            "field": "max_segmentation_distance",
+            "description": "<p>This is the maximum distance that two features that are moving relative to each other can be apart and still be considered part of the same object. If not provided, a value of .7 will be used.</p>"
           }
         ]
       }

--- a/app/static/apidoc/api_project.js
+++ b/app/static/apidoc/api_project.js
@@ -9,7 +9,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2017-01-25T18:50:17.420Z",
+    "time": "2017-01-28T17:23:51.481Z",
     "url": "http://apidocjs.com",
     "version": "0.17.3"
   }

--- a/app/static/apidoc/api_project.json
+++ b/app/static/apidoc/api_project.json
@@ -9,7 +9,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2017-01-25T18:50:17.420Z",
+    "time": "2017-01-28T17:23:51.481Z",
     "url": "http://apidocjs.com",
     "version": "0.17.3"
   }

--- a/trafficcloud/api.py
+++ b/trafficcloud/api.py
@@ -4,19 +4,21 @@
 import os
 import shutil
 from app_config import get_project_path, get_project_video_path, update_config_without_sections, get_config_without_sections
-import pm
 import subprocess
 import video, feat_config
 
+from pm import create_project
+
 from plotting.make_object_trajectories import main as db_make_objtraj
 
-def saveFiles(diction, *args):
-    return pm.ProjectWizard(diction).identifier
+def uploadVideo(identifier, video_filename):
+    return create_project(identifier, video_filename)
 
 def runConfigTestFeature(identifier, config, frames, ret_type, ret_args, *args):
     project_path = get_project_path(identifier)
-    tracking_path = os.path.join(project_path, ".temp", "test", "test_feature", "feature_tracking.cfg")
+    tracking_path = os.path.join(project_path, "tracking.cfg")
     db_path = os.path.join(project_path, ".temp", "test", "test_feature", "test1.sqlite")
+    
     if os.path.exists(db_path):
         os.remove(db_path)
 
@@ -46,15 +48,7 @@ def runTrajectoryAnalysis(identifier):#, config, ret_type, ret_args, *args):
     if not os.path.exists(os.path.join(project_path, "run")):
         os.mkdir(os.path.join(project_path, "run"))
 
-    tracking_path = os.path.join(project_path, "run", "run_tracking.cfg")
-
-    # removes object tracking.cfg
-    if os.path.exists(tracking_path):
-        os.remove(tracking_path)
-
-    # creates new config file
-    prev_tracking_path = os.path.join(project_path, ".temp", "test", "test_object", "object_tracking.cfg")
-    shutil.copyfile(prev_tracking_path, tracking_path)
+    tracking_path = os.path.join(project_path, "tracking.cfg")
 
     update_dict = {'frame1': 0, 
         'nframes': 0, 
@@ -86,7 +80,7 @@ def createVideos(identifier):
 
 def runSafetyAnalysis(identifier, prediction_method=None):
     project_path = get_project_path(identifier)
-    config_path = os.path.join(project_path, "run", "run_tracking.cfg")
+    config_path = os.path.join(project_path, "tracking.cfg")
     db_path = os.path.join(project_path, "run", "results.sqlite")
     update_dict = {
         'video-filename': get_project_video_path(identifier), # use absolute path to video on server

--- a/trafficcloud/app_config.py
+++ b/trafficcloud/app_config.py
@@ -118,7 +118,7 @@ def config_section_exists(config_path, section):
         return False               # then return False
 
 def update_config_without_sections(config_path, update_dict):
-    """helper function to edit cfg files that look like run_tracking.cfg
+    """helper function to edit cfg files that look like tracking.cfg
 
     update_dict: i.e. {'nframes': 10, 'video-filename': 'video.avi'}
     """
@@ -138,7 +138,7 @@ def update_config_without_sections(config_path, update_dict):
             
 
 def get_config_without_sections(config_path):
-    """helper function to get params and their values of cfg files that look like run_tracking.cfg
+    """helper function to get params and their values of cfg files that look like tracking.cfg
 
     get_dict: params to their values, as a dictionary
     """

--- a/trafficcloud/pm.py
+++ b/trafficcloud/pm.py
@@ -17,84 +17,102 @@ import numpy as np
 from app_config import get_project_path, get_project_config_path, config_section_exists, update_config_without_sections
 from video import get_framerate
 
-import subprocess
-import uuid
+def create_project(identifier, video_filename):
+    config_dict = {}
+    _update_config_dict_with_defaults(config_dict)
 
-class ProjectWizard():
+    _create_project_dir(identifier, config_dict)
 
-    def __init__(self,files):
-        self.dict_files = files
+def update_homography(identifier, homography_path, unitpixelratio):
+    pass
 
-        self.identifier = str(uuid.uuid4())
-        self.create_project_dir(self.identifier)
+def update_project_config(identifier, config_dict):
+    _update_config_dict_with_defaults(config_dict)
 
-    def create_project_dir(self, identifier):
-        directory_names = ["homography", os.path.join(".temp", "test", "test_object"), os.path.join(".temp", "test", "test_feature"), "run", "results"]
-        project_path = get_project_path(identifier)
+    project_path = get_project_path(identifier)
+    tracking_path = os.path.join(project_path, "tracking.cfg")
+    update_config_without_sections(tracking_path, config_dict)
 
-        if not os.path.exists(project_path):
-            # Create proj dirs
-            for new_dir in directory_names:
-                os.makedirs(os.path.join(project_path, new_dir))
+def default_config_dict():
+    return {
+        'max_features_per_frame': 1000,
+        'num_displacement_frames': 10,
+        'min_feature_displacement': 0.0001,
+        'max_iterations_to_persist': 200,
+        'min_feature_frames': 15,
+        'max_connection_distance': 1.0,
+        'max_segmentation_distance': 0.7,
+    }
 
-            # Write files from client
-            for key,value in self.dict_files.iteritems():
-                if key[:5] == 'video':
-                    self.videopath = os.path.join(project_path, key)
-                with open(os.path.join(project_path, key), 'wb') as fh:
-                    fh.write(value)
+def _update_config_dict_with_defaults(config_dict):
+    default_dict = default_config_dict()
 
+    # Remove things that we don't want the user to be able to configure
+    for key in config_dict.keys():
+        if key not in default_dict.keys():
+            del config_dict[key]
 
-            self._write_to_project_config(identifier)
+    # Add defaults for things that don't exist
+    for (key, value) in default_dict.iteritems():
+        if key not in config_dict.keys():
+            config_dict[key] = value
 
-            default_files_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "default")
+def _create_project_dir(identifier, config_dict, video_filename):
+    test_object_dir = os.path.join(".temp", "test", "test_object")
+    test_feature_dir = os.path.join(".temp", "test", "test_feature")
 
-            copy(os.path.join(default_files_dir, "tracking.cfg"), os.path.join(project_path, "tracking.cfg"))
-            copy(os.path.join(default_files_dir, "classifier.cfg"), os.path.join(project_path, "classifier.cfg"))
+    directory_names = ["homography", test_object_dir, test_feature_dir, "run", "results"]
+    project_path = get_project_path(identifier)
 
-            update_dict_1 = {
-                'classifier-filename': os.path.join(project_path, 'classifier.cfg')
-            }
-            update_config_without_sections(os.path.join(project_path, 'tracking.cfg'), update_dict_1)
+    if not os.path.exists(project_path):
+        # Create proj dirs
+        for new_dir in directory_names:
+            os.makedirs(os.path.join(project_path, new_dir))
 
-            update_dict_2 = {
-                'pbv-svm-filename': os.path.join(default_files_dir, 'modelPBV.xml'),
-                'bv-svm-filename': os.path.join(default_files_dir, 'modelBV.xml')
-            }
-            update_config_without_sections(os.path.join(project_path, 'classifier.cfg'), update_dict_2)
+        # TODO: unitpixelratio
+        _write_to_project_config(identifier)
 
-        else:
-            print("Project exists. No new project created.")
+        default_files_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "default")
 
-    def _write_to_project_config(self, identifier):
-        # Copy information given by the project_name.cfg generated client side
-        client_config_parser = SafeConfigParser()
-        client_config_parser.read(os.path.join(get_project_path(identifier), "project_name.cfg"))
-        unitpixelratio = None
-        try:
-            unitpixelratio = client_config_parser.get("homography", "unitpixelratio")
-        except NoSectionError:
-            print("NoSectionError: no 'homography' section found in config file. Unit Pixel Ratio will not be copied.")
+        tracking_path = os.path.join(project_path, "tracking.cfg")
+        classifier_path = os.path.join(project_path, "classifier.cfg")
 
-        ts = time.time()
-        vid_ts = datetime.datetime.now()
-        #This line needs to be updated to no longer need the ui class. Load video and pull time.
-        timestamp = datetime.datetime.fromtimestamp(ts).strftime('%d-%m-%Y %H:%M:%S %Z')
-        video_timestamp = vid_ts.strftime('%d-%m-%Y %H:%M:%S %Z')
-        config_parser = SafeConfigParser()
-        config_parser.add_section("info")
-        config_parser.set("info", "project_name", identifier)
-        config_parser.set("info", "creation_date", timestamp)
-        config_parser.add_section("video")
-        config_parser.set("video", "name", os.path.basename(self.videopath))
-        config_parser.set("video", "source", self.videopath)
-        config_parser.set("video", "framerate", get_framerate(self.videopath))
-        config_parser.set("video", "start", video_timestamp)
-        if unitpixelratio:
-            config_parser.add_section("homography")
-            config_parser.set("homography", "unitpixelratio", unitpixelratio)
+        copy(os.path.join(default_files_dir, "tracking.cfg"), tracking_path)
+        copy(os.path.join(default_files_dir, "classifier.cfg"), classifier_path)
 
-        with open(get_project_config_path(identifier), 'wb') as configfile:
-            config_parser.write(configfile)
+        # Add classifier path along with configuration
+        config_dict['classifier-filename'] = classifier_path
+        update_config_without_sections(tracking_path, config_dict)
 
-        os.remove(os.path.join(get_project_path(identifier), "project_name.cfg"))
+        update_dict = {
+            'pbv-svm-filename': os.path.join(default_files_dir, 'modelPBV.xml'),
+            'bv-svm-filename': os.path.join(default_files_dir, 'modelBV.xml')
+        }
+        update_config_without_sections(classifier_path, update_dict)
+
+    else:
+        print("Project exists. No new project created.")
+
+def _write_to_project_config(self, identifier, video_filename, unitpixelratio=None):
+    ts = time.time()
+    vid_ts = datetime.datetime.now()
+    #This line needs to be updated to no longer need the ui class. Load video and pull time.
+    timestamp = datetime.datetime.fromtimestamp(ts).strftime('%d-%m-%Y %H:%M:%S %Z')
+    video_timestamp = vid_ts.strftime('%d-%m-%Y %H:%M:%S %Z')
+    config_parser = SafeConfigParser()
+    config_parser.add_section("info")
+    config_parser.set("info", "project_name", identifier)
+    config_parser.set("info", "creation_date", timestamp)
+    config_parser.add_section("video")
+    config_parser.set("video", "name", os.path.basename(video_filename))
+    config_parser.set("video", "source", video_filename)
+    config_parser.set("video", "framerate", get_framerate(video_filename))
+    config_parser.set("video", "start", video_timestamp)
+    if unitpixelratio:
+        config_parser.add_section("homography")
+        config_parser.set("homography", "unitpixelratio", unitpixelratio)
+
+    with open(get_project_config_path(identifier), 'wb') as configfile:
+        config_parser.write(configfile)
+
+    os.remove(os.path.join(get_project_path(identifier), "project_name.cfg"))

--- a/trafficcloud/pm.py
+++ b/trafficcloud/pm.py
@@ -70,7 +70,7 @@ def _create_project_dir(identifier, config_dict, video_filename):
             os.makedirs(os.path.join(project_path, new_dir))
 
         # TODO: unitpixelratio
-        _write_to_project_config(identifier)
+        _write_to_project_config(identifier, video_filename)
 
         default_files_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "default")
 
@@ -93,7 +93,7 @@ def _create_project_dir(identifier, config_dict, video_filename):
     else:
         print("Project exists. No new project created.")
 
-def _write_to_project_config(self, identifier, video_filename, unitpixelratio=None):
+def _write_to_project_config(identifier, video_filename, unitpixelratio=None):
     ts = time.time()
     vid_ts = datetime.datetime.now()
     #This line needs to be updated to no longer need the ui class. Load video and pull time.
@@ -104,9 +104,9 @@ def _write_to_project_config(self, identifier, video_filename, unitpixelratio=No
     config_parser.set("info", "project_name", identifier)
     config_parser.set("info", "creation_date", timestamp)
     config_parser.add_section("video")
-    config_parser.set("video", "name", os.path.basename(video_filename))
+    config_parser.set("video", "name", video_filename)
     config_parser.set("video", "source", video_filename)
-    config_parser.set("video", "framerate", get_framerate(video_filename))
+    config_parser.set("video", "framerate", get_framerate(os.path.join(get_project_path(identifier), video_filename)))
     config_parser.set("video", "start", video_timestamp)
     if unitpixelratio:
         config_parser.add_section("homography")
@@ -114,5 +114,3 @@ def _write_to_project_config(self, identifier, video_filename, unitpixelratio=No
 
     with open(get_project_config_path(identifier), 'wb') as configfile:
         config_parser.write(configfile)
-
-    os.remove(os.path.join(get_project_path(identifier), "project_name.cfg"))


### PR DESCRIPTION
Refactors pm.py for 
- Static methods that take identifiers rather than instance creation
- Updating config
- Only keeping one copy of tracking.cfg

Adds config route that
- Updates tracking.cfg

Untested, and can't really be until Deniz's changes get merged. I need his stuff to be done in order to hook up his uploadVideo and uploadHomography routes to my pm changes.