### PR TITLE
Base handler returns error properly

### DIFF
--- a/app/handlers/analysis.py
+++ b/app/handlers/analysis.py
@@ -9,8 +9,9 @@ from traffic_cloud_utils.app_config import get_project_path, get_project_video_p
 from traffic_cloud_utils.emailHelper import EmailHelper
 from objectTracking import ObjectTrackingHandler
 from safetyAnalysis import SafetyAnalysisHandler
+from baseHandler import BaseHandler
 
-class AnalysisHandler(tornado.web.RequestHandler):
+class AnalysisHandler(BaseHandler):
     """
     @api {post} /analysis/ Analysis
     @apiName Analysis
@@ -40,5 +41,6 @@ class AnalysisHandler(tornado.web.RequestHandler):
                 EmailHelper.send_email(email, subject, message)
             self.finish("Analysis")
         else:
-            raise tornado.web.HTTPError(reason=reason, status_code=status_code)
-        
+            self.error_message = reason
+            raise tornado.web.HTTPError(status_code=status_code)
+

--- a/app/handlers/baseHandler.py
+++ b/app/handlers/baseHandler.py
@@ -15,6 +15,7 @@ class BaseHandler(tornado.web.RequestHandler):
 
         if self.error_message != None:
             error_dict['message'] = self.error_message
+            print("ERROR: "+self.error_message)
 
         if self.settings.get('serve_traceback') and 'exc_info' in kwargs:
             lines = []

--- a/app/handlers/baseHandler.py
+++ b/app/handlers/baseHandler.py
@@ -3,21 +3,24 @@ import json
 import traceback
 
 class BaseHandler(tornado.web.RequestHandler):
+    def initialize(self):
+        self.error_message = None
+
     def write_error(self, status_code, **kwargs):
         self.set_header('Content-Type', 'application/json')
+
+        error_dict = {
+            'code': status_code
+        }
+
+        if self.error_message != None:
+            error_dict['message'] = self.error_message
+
         if self.settings.get('serve_traceback') and 'exc_info' in kwargs:
             lines = []
             for line in traceback.format_exception(*kwargs['exc_info']):
                 lines.append(line)
-            self.finish(json.dumps({
-                'error': {
-                    'code': status_code,
-                    'message': self._reason,
-                    'traceback': lines,
-                }}))
-        else:
-            self.finish(json.dumps({
-                'error': {
-                    'code': status_code,
-                    'message': self._reason,
-                }}))
+            error_dict['traceback'] = lines
+
+        self.finish(json.dumps({
+            'error': error_dict }))

--- a/app/handlers/createHighlightVideo.py
+++ b/app/handlers/createHighlightVideo.py
@@ -7,10 +7,10 @@ from traffic_cloud_utils.video import create_highlight_video, get_framerate
 from storage import alterInteractionsWithRoadUserType, getNearMissFrames
 from traffic_cloud_utils.app_config import get_project_path, get_project_video_path
 from traffic_cloud_utils.statusHelper import StatusHelper
-import baseHandler
+from baseHandler import BaseHandler
 
 # TODO: remove once pip's error request handler is written
-class CreateHighlightVideoHandler(baseHandler.BaseHandler):
+class CreateHighlightVideoHandler(BaseHandler):
     """
     @api {post} /highlightVideo/ Highlight Video
     @apiName HighlightVideo
@@ -35,7 +35,8 @@ class CreateHighlightVideoHandler(baseHandler.BaseHandler):
         if status_code == 200:
             self.finish("Create Highlight Video")
         else:
-            raise tornado.web.HTTPError(reason=reason, status_code=status_code)
+            self.error_message = reason
+            raise tornado.web.HTTPError(status_code=status_code)
 
     @staticmethod
     def handler(identifier, ttc_threshold, vehicle_only):

--- a/app/handlers/createSpeedCDF.py
+++ b/app/handlers/createSpeedCDF.py
@@ -2,7 +2,7 @@
 
 import os
 import tornado.web
-import baseHandler
+from baseHandler import BaseHandler
 from traffic_cloud_utils.app_config import get_project_path, get_project_video_path
 from traffic_cloud_utils.video import get_framerate
 from traffic_cloud_utils.plotting.visualization import vel_cdf
@@ -10,7 +10,7 @@ from traffic_cloud_utils.plotting.visualization import vel_cdf
 import json
 import traceback
 
-class CreateSpeedCDFHandler(baseHandler.BaseHandler):
+class CreateSpeedCDFHandler(BaseHandler):
     """
     @api {post} /speedCDF/ Speed CDF
     @apiName SpeedCDF
@@ -52,7 +52,7 @@ class CreateSpeedCDFHandler(baseHandler.BaseHandler):
 
         video_path = get_project_video_path(identifier)
         if not os.path.exists(video_path):
-            return (500, 'Source video file does not exist.  Was the video uploaded?')        
+            return (500, 'Source video file does not exist.  Was the video uploaded?')
 
         vel_cdf(db, float(get_framerate(video_path)), speed_limit, final_images, vehicle_only)
 

--- a/app/handlers/makeReport.py
+++ b/app/handlers/makeReport.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 import tornado.web
+from baseHandler import BaseHandler
 
-class MakeReportHandler(tornado.web.RequestHandler):
+class MakeReportHandler(BaseHandler):
     """
     @api {post} /makeReport/ Make Report
     @apiName MakeReport

--- a/app/handlers/makeReport.py
+++ b/app/handlers/makeReport.py
@@ -5,9 +5,9 @@ import tornado.web
 from traffic_cloud_utils.pdf_generate import makePdf
 from traffic_cloud_utils.app_config import get_project_path
 
-import baseHandler
+from baseHandler import BaseHandler
 
-class MakeReportHandler(baseHandler.BaseHandler):
+class MakeReportHandler(BaseHandler):
     """
     @api {post} /makeReport/ Make Report
     @apiName MakeReport

--- a/app/handlers/makeReport.py
+++ b/app/handlers/makeReport.py
@@ -27,7 +27,8 @@ class MakeReportHandler(BaseHandler):
         if status_code == 200:
             self.finish("Make PDF Report")
         else:
-            raise tornado.web.HTTPError(reason=reason, status_code=status_code)
+            self.error_message = reason
+            raise tornado.web.HTTPError(status_code=status_code)
 
     @staticmethod
     def handler(identifier):
@@ -40,7 +41,7 @@ class MakeReportHandler(BaseHandler):
             os.mkdir(final_images)
 
         report_path = os.path.join(project_dir, 'santosreport.pdf')
-        
+
         # Hardcoded image file name order, so that the ordering of visuals in the report is consistent
         image_fns = [
             os.path.join(final_images, 'road_user_icon_counts.png'),

--- a/app/handlers/retrieveResults.py
+++ b/app/handlers/retrieveResults.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 import tornado.web
+from baseHandler import BaseHandler
 
-class RetrieveResultsHandler(tornado.web.RequestHandler):
+class RetrieveResultsHandler(BaseHandler):
     """
     @api {get} /retrieveResults/ Retrieve Results
     @apiName RetrieveResults

--- a/app/handlers/roadUserCounts.py
+++ b/app/handlers/roadUserCounts.py
@@ -6,10 +6,10 @@ import tornado.escape
 
 from traffic_cloud_utils.plotting.visualization import road_user_counts, road_user_icon_counts
 from traffic_cloud_utils.app_config import get_project_path
-import baseHandler
+from baseHandler import BaseHandler
 
 #TODO(rlouie): replace with SantosBaseHandler class pip makes
-class RoadUserCountsHandler(baseHandler.BaseHandler):
+class RoadUserCountsHandler(BaseHandler):
     """
     @api {post} /roadUserCounts/ Road User Counts
     @apiName RoadUserCounts
@@ -31,7 +31,8 @@ class RoadUserCountsHandler(baseHandler.BaseHandler):
         if status_code == 200:
             self.finish("Visualize Road User Counts")
         else:
-            raise tornado.web.HTTPError(reason=reason, status_code=status_code)
+            self.error_message = reason
+            raise tornado.web.HTTPError(status_code=status_code)
 
     @staticmethod
     def handler(identifier):
@@ -47,7 +48,7 @@ class RoadUserCountsHandler(baseHandler.BaseHandler):
         if not os.path.exists(final_images):
             os.mkdir(final_images)
 
-        try:        
+        try:
             counts = road_user_counts(db)
         except Exception as err_msg:
             return (500, err_msg)

--- a/app/handlers/safetyAnalysis.py
+++ b/app/handlers/safetyAnalysis.py
@@ -4,12 +4,13 @@ import subprocess
 
 import tornado.web
 
+from baseHandler import BaseHandler
 from traffic_cloud_utils.app_config import get_project_path, get_project_video_path, update_config_without_sections, get_config_without_sections
 from traffic_cloud_utils.emailHelper import EmailHelper
 from traffic_cloud_utils.statusHelper import StatusHelper
 
 
-class SafetyAnalysisHandler(tornado.web.RequestHandler):
+class SafetyAnalysisHandler(BaseHandler):
     """
     @api {post} /safetyAnalysis/ Safety Analysis
     @apiName SafetyAnalysis
@@ -26,7 +27,7 @@ class SafetyAnalysisHandler(tornado.web.RequestHandler):
     """
     def post(self):
         status_code, reason = self.handler(self.get_body_argument("identifier"))
-        email = self.get_body_argument("email", default = None) 
+        email = self.get_body_argument("email", default = None)
 
         if status_code == 200:
             if not email == None:
@@ -36,7 +37,8 @@ class SafetyAnalysisHandler(tornado.web.RequestHandler):
                 EmailHelper.send_email(email, subject, message)
             self.finish("Safety Analysis")
         else:
-            raise tornado.web.HTTPError(reason=reason, status_code=status_code)
+            self.error_message = reason
+            raise tornado.web.HTTPError(status_code=status_code)
 
 
     @staticmethod
@@ -53,7 +55,7 @@ class SafetyAnalysisHandler(tornado.web.RequestHandler):
             'video-filename': get_project_video_path(identifier), # use absolute path to video on server
             'database-filename': db_path # use absolute path to database
         }
-        
+
         update_config_without_sections(config_path, update_dict)
 
         if prediction_method is None:

--- a/app/handlers/status.py
+++ b/app/handlers/status.py
@@ -2,8 +2,9 @@
 
 import tornado.web
 from traffic_cloud_utils.statusHelper import StatusHelper
+from baseHandler import BaseHandler
 
-class StatusHandler(tornado.web.RequestHandler):
+class StatusHandler(BaseHandler):
 
     """
     @api {post} /status/ Processing Status

--- a/app/handlers/testConfig.py
+++ b/app/handlers/testConfig.py
@@ -5,13 +5,14 @@ import shutil
 
 import tornado.web
 
+from baseHandler import BaseHandler
 from traffic_cloud_utils.app_config import get_project_path, get_project_video_path, update_config_without_sections, get_config_without_sections
 from traffic_cloud_utils.emailHelper import EmailHelper
 from traffic_cloud_utils.app_config import update_config_without_sections
 from traffic_cloud_utils.statusHelper import StatusHelper
 from traffic_cloud_utils import video
 
-class TestConfigHandler(tornado.web.RequestHandler):
+class TestConfigHandler(BaseHandler):
     """
     @api {post} /testConfig/ Test Configuration
     @apiName TestConfig
@@ -48,7 +49,8 @@ class TestConfigHandler(tornado.web.RequestHandler):
         if status_code == 200:
             self.finish("Testing tracking")
         else:
-            raise tornado.web.HTTPError(reason=reason, status_code=status_code)
+            self.error_message = reason
+            raise tornado.web.HTTPError(status_code=status_code)
 
     def runConfigTestFeature(self, identifier, frame_start, num_frames):
         StatusHelper.set_status(identifier, "configuration_test", 1)
@@ -66,7 +68,7 @@ class TestConfigHandler(tornado.web.RequestHandler):
         update_config_without_sections(tracking_path, testing_dict)
 
         images_folder = "feature_images"
-        video.delete_files(images_folder)        
+        video.delete_files(images_folder)
 
         try:
             subprocess.check_output(["feature-based-tracking", tracking_path, "--tf", "--database-filename", db_path])

--- a/app/handlers/upload.py
+++ b/app/handlers/upload.py
@@ -3,9 +3,10 @@
 import tornado.web
 import os
 import uuid
+from baseHandler import BaseHandler
 
-class UploadHandler(tornado.web.RequestHandler):
-    
+class UploadHandler(BaseHandler):
+
     @staticmethod
     def parse_request(files):
         name_body_dict = {}

--- a/app/handlers/uploadHomography.py
+++ b/app/handlers/uploadHomography.py
@@ -8,8 +8,9 @@ from traffic_cloud_utils.statusHelper import StatusHelper
 import numpy as np
 import cv2
 from ast import literal_eval
+from baseHandler import BaseHandler
 
-class UploadHomographyHandler(tornado.web.RequestHandler):
+class UploadHomographyHandler(BaseHandler):
     """
     @api {post} /uploadHomography/ Upload Homography
     @apiName UploadHomography
@@ -29,6 +30,9 @@ class UploadHomographyHandler(tornado.web.RequestHandler):
     @apiError error_message The error message to display.
     """
     def initialize(self):
+        # Make sure the BaseHandler is initialized
+        super(UploadHomographyHandler, self).initialize()
+
         self.identifier = None
         self.files = {}
 
@@ -40,7 +44,7 @@ class UploadHomographyHandler(tornado.web.RequestHandler):
         self.write_homography_files()
         StatusHelper.set_status(self.identifier, "upload_homography", 2)
         self.finish("Upload Homography")
-        
+
     def write_homography_files(self):
         project_dir = get_project_path(self.identifier)
         aerial_pts = self.get_body_argument('aerial_pts')
@@ -54,7 +58,7 @@ class UploadHomographyHandler(tornado.web.RequestHandler):
             if (key == 'aerial' or key == 'camera'):
                 with open(os.path.join(project_dir,'homography',value[0]['filename']), 'wb') as f:
                     f.write(value[0]['body'])
-        
-        
+
+
 
 


### PR DESCRIPTION
`HTTPError(reason=reason, ...)` fails when there is a newline in reason, because it tries to write the reason to a header (like '404 Not Found'). The solution is to use an `error_message` property, and inherit from BaseHandler everywhere.