### PR TITLE
FIX: safety report opens in Preview on MacOS

### DIFF
--- a/app/handlers/makeReport.py
+++ b/app/handlers/makeReport.py
@@ -44,8 +44,8 @@ class MakeReportHandler(BaseHandler):
 
         # Hardcoded image file name order, so that the ordering of visuals in the report is consistent
         image_fns = [
-            os.path.join(final_images, 'road_user_icon_counts.png'),
-            os.path.join(final_images, 'velocityCDF.png')
+            os.path.join(final_images, 'road_user_icon_counts.jpg'),
+            os.path.join(final_images, 'velocityCDF.jpg')
         ]
 
         makePdf(report_path, image_fns, final_images)

--- a/app/handlers/roadUserCounts.py
+++ b/app/handlers/roadUserCounts.py
@@ -58,7 +58,7 @@ class RoadUserCountsHandler(BaseHandler):
                 car=counts['car'],
                 bike=counts['bicycle'],
                 pedestrian=counts['pedestrian'],
-                save_path=os.path.join(final_images, 'road_user_icon_counts.png'))
+                save_path=os.path.join(final_images, 'road_user_icon_counts.jpg'))
         except Exception as err_msg:
             return (500, err_msg)
 

--- a/app/traffic_cloud_utils/plotting/visualization.py
+++ b/app/traffic_cloud_utils/plotting/visualization.py
@@ -350,7 +350,7 @@ def vel_cdf(filename, fps, speed_limit=25, dir=None, only_vehicle=True):
     thinkplot.Vlines(speed_limit, 0, 1)
     thinkplot.Config(title=titlestring, xlabel='Velocity (mph)', ylabel='CDF')
     if dir is not None:
-        thinkplot.Save(os.path.join(dir, 'velocityCDF'), formats=['png'], bbox_inches='tight')
+        thinkplot.Save(os.path.join(dir, 'velocityCDF'), formats=['jpg'], bbox_inches='tight')
     else:
         thinkplot.Show()
 
@@ -477,7 +477,7 @@ def road_user_icon_counts(title, car, bike, pedestrian, save_path, textcolor='#0
     # bike count
     ax.text(ped_loc*mpl_width, text_y*mpl_height, str(pedestrian), horizontalalignment='center', fontsize=fontsize, color=textcolor)
 
-    fig.savefig(save_path, dpi=dpi, bbox_inches=0, pad_inches=0, facecolor=facecolor)
+    fig.savefig(save_path, dpi=dpi, bbox_inches=0, pad_inches=0, facecolor=facecolor, format='jpg')
 
 if __name__ == '__main__':
     import argparse


### PR DESCRIPTION
Summary: Learned of an issue in pyfpdf where images that are
transparent (4 channel) cannot be viewed in certain viewers.
Now, we save all visualizations as 3 channel jpg images.

Tests: Generated new santosreport and was able to open in
Preview on MacOS. 

Try the pdf that was generated yourself
[santosreport.pdf](https://github.com/santosfamilyfoundation/SantosCloud/files/761116/santosreport.pdf)
