### PR TITLE
Output directory

### DIFF
--- a/app/handlers/testConfig.py
+++ b/app/handlers/testConfig.py
@@ -122,7 +122,7 @@ class TestConfigFeatureThread(threading.Thread):
         video.create_video_from_images(images_folder, temp_image_prefix, videos_folder, video_filename, video.get_framerate(get_project_video_path(self.identifier)))
 
         video.delete_files(images_folder)
-        os.remove(images_folder)
+        os.rmdir(images_folder)
 
         StatusHelper.set_status(self.identifier, "configuration_test", 2)
         return self.callback(200, "Test config done", self.identifier)
@@ -173,7 +173,7 @@ class TestConfigObjectThread(threading.Thread):
         video.create_video_from_images(images_folder, temp_image_prefix, videos_folder, video_filename, video.get_framerate(get_project_video_path(self.identifier)))
 
         video.delete_files(images_folder)
-        os.remove(images_folder)
+        os.rmdir(images_folder)
 
         StatusHelper.set_status(self.identifier, "configuration_test", 2)
         return self.callback(200, "Test config done", self.identifier)

--- a/app/handlers/testConfig.py
+++ b/app/handlers/testConfig.py
@@ -121,6 +121,9 @@ class TestConfigFeatureThread(threading.Thread):
         temp_image_prefix = 'image-'
         video.create_video_from_images(images_folder, temp_image_prefix, videos_folder, video_filename, video.get_framerate(get_project_video_path(self.identifier)))
 
+        video.delete_files(images_folder)
+        os.remove(images_folder)
+
         StatusHelper.set_status(self.identifier, "configuration_test", 2)
         return self.callback(200, "Test config done", self.identifier)
 
@@ -168,6 +171,9 @@ class TestConfigObjectThread(threading.Thread):
         video_filename = "object_video.mp4"
         temp_image_prefix = 'image-'
         video.create_video_from_images(images_folder, temp_image_prefix, videos_folder, video_filename, video.get_framerate(get_project_video_path(self.identifier)))
+
+        video.delete_files(images_folder)
+        os.remove(images_folder)
 
         StatusHelper.set_status(self.identifier, "configuration_test", 2)
         return self.callback(200, "Test config done", self.identifier)

--- a/app/handlers/testConfig.py
+++ b/app/handlers/testConfig.py
@@ -106,18 +106,20 @@ class TestConfigFeatureThread(threading.Thread):
 
         images_folder = os.path.join(get_project_path(self.identifier), "feature_images")
         video.delete_files(images_folder)
+        if not os.path.exists(images_folder):
+            os.mkdir(images_folder)
 
         try:
             subprocess.check_output(["feature-based-tracking", tracking_path, "--tf", "--database-filename", db_path])
-            subprocess.check_output(["display-trajectories.py", "-i", get_project_video_path(self.identifier), "-d", db_path, "-o", project_path + "/homography/homography.txt", "-t", "feature", "--save-images", "-f", str(self.frame_start), "--last-frame", str(self.frame_start + self.num_frames)])
+            subprocess.check_output(["display-trajectories.py", "-i", get_project_video_path(self.identifier), "-d", db_path, "-o", project_path + "/homography/homography.txt", "-t", "feature", "--save-images", "-f", str(self.frame_start), "--last-frame", str(self.frame_start + self.num_frames), "--output-directory", images_folder])
         except subprocess.CalledProcessError as err_msg:
             StatusHelper.set_status(self.identifier, "configuration_test", -1)
             return self.callback(500, err_msg.output, self.identifier)
 
-        videos_folder = os.path.join(get_project_path(self.identifier), "feature_images")
+        videos_folder = os.path.join(get_project_path(self.identifier), "feature_video")
         video_filename = "feature_video.mp4"
         temp_image_prefix = 'image-'
-        video.create_video_from_images(os.getcwd(), temp_image_prefix, videos_folder, video_filename, video.get_framerate(get_project_video_path(self.identifier)))
+        video.create_video_from_images(images_folder, temp_image_prefix, videos_folder, video_filename, video.get_framerate(get_project_video_path(self.identifier)))
 
         StatusHelper.set_status(self.identifier, "configuration_test", 2)
         return self.callback(200, "Test config done", self.identifier)
@@ -151,21 +153,24 @@ class TestConfigObjectThread(threading.Thread):
 
         images_folder = os.path.join(get_project_path(self.identifier), "object_images")
         video.delete_files(images_folder)
+        if not os.path.exists(images_folder):
+            os.mkdir(images_folder)
 
         try:
             subprocess.check_output(["feature-based-tracking",tracking_path,"--gf","--database-filename",obj_db_path])
             subprocess.check_output(["classify-objects.py", "--cfg", tracking_path, "-d", obj_db_path])  # Classify road users
-            subprocess.check_output(["display-trajectories.py", "-i", get_project_video_path(self.identifier),"-d", obj_db_path, "-o", project_path + "/homography/homography.txt", "-t", "object", "--save-images", "-f", str(self.frame_start), "--last-frame", str(self.frame_start + self.num_frames)])
+            subprocess.check_output(["display-trajectories.py", "-i", get_project_video_path(self.identifier),"-d", obj_db_path, "-o", project_path + "/homography/homography.txt", "-t", "object", "--save-images", "-f", str(self.frame_start), "--last-frame", str(self.frame_start + self.num_frames), "--output-directory", images_folder])
         except subprocess.CalledProcessError as err_msg:
             StatusHelper.set_status(self.identifier, "configuration_test", -1)
             return self.callback(500, err_msg.output, self.identifier)
 
-        videos_folder = os.path.join(get_project_path(self.identifier), "object_images")
+        videos_folder = os.path.join(get_project_path(self.identifier), "object_video")
         video_filename = "object_video.mp4"
         temp_image_prefix = 'image-'
-        video.create_video_from_images(os.getcwd(), temp_image_prefix, videos_folder, video_filename, video.get_framerate(get_project_video_path(self.identifier)))
+        video.create_video_from_images(images_folder, temp_image_prefix, videos_folder, video_filename, video.get_framerate(get_project_video_path(self.identifier)))
 
         StatusHelper.set_status(self.identifier, "configuration_test", 2)
         return self.callback(200, "Test config done", self.identifier)
+
 
 

--- a/app/traffic_cloud_utils/video.py
+++ b/app/traffic_cloud_utils/video.py
@@ -157,8 +157,7 @@ def create_video_snippet(project_path, video_path, videos_folder, file_prefix, v
 
     # Delete old images, and recreate them in the right place
     delete_files(images_folder, temp_image_prefix, ["png"], excluded_files=[tracking_filename, highlight_filename])
-    subprocess.call(["display-trajectories.py", "-i", video_path,"-d", db_path, "-o", os.path.join(project_path, "homography", "homography.txt"), "-t", "object", "--save-images", "-f", str(start_frame), "--last-frame", str(end_frame)])
-    move_files_to_folder(os.getcwd(), images_folder, temp_image_prefix, ["png"])
+    subprocess.call(["display-trajectories.py", "-i", video_path,"-d", db_path, "-o", os.path.join(project_path, "homography", "homography.txt"), "-t", "object", "--save-images", "-f", str(start_frame), "--last-frame", str(end_frame), "--output-directory", images_folder])
 
     # Get the frames, and create a short video out of them
     renumber_frames(images_folder, start_frame, temp_image_prefix, "png")

--- a/app/traffic_cloud_utils/video.py
+++ b/app/traffic_cloud_utils/video.py
@@ -84,12 +84,15 @@ def delete_files(folder, prefix="", extensions=[], excluded_files=[]):
         for file in os.listdir(folder):
             if file.startswith(prefix):
                 s = file.split('.')
-                if len(s) == 2:
+                has_extension = len(s) == 2
+                extension_excluded = False
+                if has_extension:
                     e = s[1]
-                    # Then check extension is correct
-                    if len(extensions) == 0 or e in extensions:
-                        if not file in excluded_files:
-                            os.remove(os.path.join(folder, file))
+                    if e in extensions:
+                        extension_excluded = True
+                if not extension_excluded:
+                    if not file in excluded_files:
+                        os.remove(os.path.join(folder, file))
 
 def get_list_of_files(folder, prefix, extension):
     count = 0

--- a/app/traffic_cloud_utils/video.py
+++ b/app/traffic_cloud_utils/video.py
@@ -80,28 +80,22 @@ def move_files_to_folder(from_folder, to_folder, prefix, extensions):
                     os.rename(os.path.join(from_folder, file), os.path.join(to_folder, file))
 
 def delete_files(folder, prefix="", extensions=[], excluded_files=[]):
-    print("HI")
-    print(folder)
-    print(prefix)
-    print(extensions)
-    print(excluded_files)
     if os.path.exists(folder):
         for file in os.listdir(folder):
-            print("Looking at file: "+file)
             if file.startswith(prefix):
-                print("Has prefix")
                 s = file.split('.')
                 has_extension = len(s) == 2
                 extension_included = True
-                print (has_extension, extension_excluded)
+
+                # If it has an extension, don't delete it if it doesn't have an extension provided
                 if has_extension:
                     e = s[1]
                     if len(extensions) > 0 and e not in extensions:
                         extension_included = False
-                        print("Extension excluded")
+
+                # If it has an extension that should be deleted (or extensions don't exist), and not in excluded files, delete it
                 if extension_included:
                     if not file in excluded_files:
-                        print("File deleted: "+file)
                         os.remove(os.path.join(folder, file))
 
 def get_list_of_files(folder, prefix, extension):

--- a/app/traffic_cloud_utils/video.py
+++ b/app/traffic_cloud_utils/video.py
@@ -167,8 +167,6 @@ def create_video_snippet(project_path, video_path, videos_folder, file_prefix, v
     subprocess.call(["display-trajectories.py", "-i", video_path,"-d", db_path, "-o", os.path.join(project_path, "homography", "homography.txt"), "-t", "object", "--save-images", "-f", str(start_frame), "--last-frame", str(end_frame), "--output-directory", images_folder])
 
     # Get the frames, and create a short video out of them
-    print(images_folder)
-    print(start_frame)
     renumber_frames(images_folder, start_frame, temp_image_prefix, "png")
     convert_frames_to_video(get_framerate(video_path), images_folder, videos_folder, temp_image_prefix, file_prefix + str(video_number) + ".mpg", pts_multiplier)
 

--- a/app/traffic_cloud_utils/video.py
+++ b/app/traffic_cloud_utils/video.py
@@ -144,10 +144,10 @@ def create_video_from_images(images_dir, prefix, video_dir, video_filename, fram
     '''
     Creates a video for images that are of the form prefix+number+.extension
     '''
-    move_files_to_folder(images_dir,video_dir,prefix, extension)
-    renumber_frames(video_dir, 0, prefix, extension)
-    convert_frames_to_video(framerate, video_dir, video_dir, prefix, video_filename, 1.0)
-    delete_files(video_dir, prefix=prefix, extensions=[extension])
+    if not os.path.exists(video_dir):
+        os.mkdir(video_dir)
+    renumber_frames(images_dir, 0, prefix, extension)
+    convert_frames_to_video(framerate, images_dir, video_dir, prefix, video_filename, 1.0)
 
 def create_video_snippet(project_path, video_path, videos_folder, file_prefix, video_number, start_frame, end_frame, pts_multiplier=1.0):
     images_folder = os.path.join(project_path, "temp_images")

--- a/app/traffic_cloud_utils/video.py
+++ b/app/traffic_cloud_utils/video.py
@@ -80,18 +80,28 @@ def move_files_to_folder(from_folder, to_folder, prefix, extensions):
                     os.rename(os.path.join(from_folder, file), os.path.join(to_folder, file))
 
 def delete_files(folder, prefix="", extensions=[], excluded_files=[]):
+    print("HI")
+    print(folder)
+    print(prefix)
+    print(extensions)
+    print(excluded_files)
     if os.path.exists(folder):
         for file in os.listdir(folder):
+            print("Looking at file: "+file)
             if file.startswith(prefix):
+                print("Has prefix")
                 s = file.split('.')
                 has_extension = len(s) == 2
-                extension_excluded = False
+                extension_included = True
+                print (has_extension, extension_excluded)
                 if has_extension:
                     e = s[1]
-                    if e in extensions:
-                        extension_excluded = True
-                if not extension_excluded:
+                    if len(extensions) > 0 and e not in extensions:
+                        extension_included = False
+                        print("Extension excluded")
+                if extension_included:
                     if not file in excluded_files:
+                        print("File deleted: "+file)
                         os.remove(os.path.join(folder, file))
 
 def get_list_of_files(folder, prefix, extension):
@@ -163,6 +173,8 @@ def create_video_snippet(project_path, video_path, videos_folder, file_prefix, v
     subprocess.call(["display-trajectories.py", "-i", video_path,"-d", db_path, "-o", os.path.join(project_path, "homography", "homography.txt"), "-t", "object", "--save-images", "-f", str(start_frame), "--last-frame", str(end_frame), "--output-directory", images_folder])
 
     # Get the frames, and create a short video out of them
+    print(images_folder)
+    print(start_frame)
     renumber_frames(images_folder, start_frame, temp_image_prefix, "png")
     convert_frames_to_video(get_framerate(video_path), images_folder, videos_folder, temp_image_prefix, file_prefix + str(video_number) + ".mpg", pts_multiplier)
 
@@ -213,7 +225,7 @@ def renumber_frames(folder, start_frame, prefix, extension):
                     except:
                         print("Couldn't parse to int: "+file+" from prefix: "+prefix)
                     if num < 0:
-                        raise Error()
+                        raise Exception()
                     new_file = prefix+str(num)+'.'+extension
                     os.rename(os.path.join(folder, file), os.path.join(temp_folder, new_file))
 


### PR DESCRIPTION
Changes:
- Refactor `delete_files` to delete all files (including without and extension) if no extensions are provided
- Use the new `--output-directory` flag of display-trajectories.py. See https://bitbucket.org/santosfamilyfoundation/trafficintelligence/pull-requests/1/display-trajectories-output/diff
- Delete all images that were created during video creation