### PR TITLE
UPDATE: highlight video and speed distribution viz

### DIFF
--- a/app/handlers/makeReport.py
+++ b/app/handlers/makeReport.py
@@ -45,7 +45,8 @@ class MakeReportHandler(BaseHandler):
         # Hardcoded image file name order, so that the ordering of visuals in the report is consistent
         image_fns = [
             os.path.join(final_images, 'road_user_icon_counts.jpg'),
-            os.path.join(final_images, 'velocityCDF.jpg')
+            os.path.join(final_images, 'velocityCDF.jpg'),
+            os.path.join(final_images, 'velocityPDF.jpg')
         ]
 
         makePdf(report_path, image_fns, final_images)

--- a/app/traffic_cloud_utils/plotting/visualization.py
+++ b/app/traffic_cloud_utils/plotting/visualization.py
@@ -8,7 +8,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.offsetbox import OffsetImage, AnnotationBbox
 import random
-from thinkstats2 import Cdf
+from thinkstats2 import Cdf, EstimatedPdf
 import thinkplot
 
 from numpy.linalg.linalg import inv
@@ -339,8 +339,10 @@ def vel_cdf(filename, fps, speed_limit=25, dir=None, only_vehicle=True):
             yvels = []
 
     cdf = Cdf(obj_vels)
+    kdepdf = EstimatedPdf(obj_vels)
     pr = cdf.PercentileRank(speed_limit)
 
+    thinkplot.PrePlot(1)
     titlestring = "{:0.1f} % of {} are exceeding the {} mph limit".format(
         100 - pr,
         'vehicles' if only_vehicle else 'road users',
@@ -350,6 +352,15 @@ def vel_cdf(filename, fps, speed_limit=25, dir=None, only_vehicle=True):
     thinkplot.Config(title=titlestring, xlabel='Velocity (mph)', ylabel='CDF')
     if dir is not None:
         thinkplot.Save(os.path.join(dir, 'velocityCDF'), formats=['jpg'], bbox_inches='tight')
+    else:
+        thinkplot.Show()
+
+    thinkplot.PrePlot(1)
+    thinkplot.Pdf(kdepdf)
+    thinkplot.Vlines(speed_limit, 0, 0.05)
+    thinkplot.Config(title=titlestring, xlabel='Velocity (mph)', ylabel='PDF')
+    if dir is not None:
+        thinkplot.Save(os.path.join(dir, 'velocityPDF'), formats=['jpg'], bbox_inches='tight')
     else:
         thinkplot.Show()
 


### PR DESCRIPTION

Summary:

- highlight video will specify only the interacitng objects
- probability density function of speed is produced and saved in the report


![velocitypdf](https://cloud.githubusercontent.com/assets/5459644/22757834/5adf421a-ee1a-11e6-9eb7-71828c2fdb07.jpg)

Making the highlight video object numbers appear only for the objects of interest