### PR TITLE
Removed uses of alterInteractionsTableWithRoadUser

### DIFF
--- a/app/handlers/createHighlightVideo.py
+++ b/app/handlers/createHighlightVideo.py
@@ -5,7 +5,7 @@ import threading
 import tornado.web
 import tornado.escape
 
-from storage import alterInteractionsWithRoadUserType, getNearMissFrames
+from storage import getNearMissFrames
 
 from baseHandler import BaseHandler
 from traffic_cloud_utils.video import create_highlight_video, get_framerate
@@ -74,12 +74,6 @@ class CreateHighlightVideoHandler(BaseHandler):
         if not os.path.exists(video_path):
             StatusHelper.set_status(identifier, Status.Type.HIGHLIGHT_VIDEO, Status.Flag.FAILURE)
             return (500, 'Source video file does not exist.  Was the video uploaded?')
-
-        try:
-            alterInteractionsWithRoadUserType(db)
-        except Exception as error_message:
-            StatusHelper.set_status(identifier, Status.Type.HIGHLIGHT_VIDEO, Status.Flag.FAILURE)
-            return (500, "Alter Interactions Table with Road User Type failed\n" + str(error_message))
 
         ttc_threshold_frames = int(ttc_threshold * float(get_framerate(video_path)))
 

--- a/app/traffic_cloud_utils/video.py
+++ b/app/traffic_cloud_utils/video.py
@@ -175,6 +175,7 @@ def create_video_snippet(project_path, video_path, videos_folder, file_prefix, v
         "--save-images",
         "-f", str(start_frame),
         "--last-frame", str(end_frame),
+        "--output-directory", images_folder,
         ]
     if interacting_objects is not None:
         display_trajectories_call.extend(['--interacting-objects', str(interacting_objects[0]), str(interacting_objects[1])])


### PR DESCRIPTION
Nicolas recommended me to remove that function, since it was populating duplicate columns in the database.  That change has been made in Traffic Intelligence, so I wanted to also remove the calls from the Cloud.  

Commit in TrafficIntelligence that is relevant:
https://bitbucket.org/santosfamilyfoundation/trafficintelligence/commits/ae22dd1b856ee681c808e9f8af5fde3f2d64914b

In order to test, get the latest version of Traffic Intelligence default.