### PR TITLE
Retrieve test results

### DIFF
--- a/app/handlers/retrieveResults.py
+++ b/app/handlers/retrieveResults.py
@@ -22,6 +22,7 @@ class RetrieveResultsHandler(BaseHandler):
 
     @apiError error_message The error message to display.
     """
+
     def get(self):
         identifier = self.get_body_argument('identifier')
         project_path = get_project_path(identifier)
@@ -41,8 +42,13 @@ class RetrieveResultsHandler(BaseHandler):
             for file in files:
                 file_path = os.path.join(root, file)
                 zipf.write(file_path, file)
-        # Write report
-        zipf.write(file_report, os.path.basename(file_report))
+        # Write report, if there
+        try:
+            zipf.write(file_report, os.path.basename(file_report))
+        except:
+            status_code = 500
+            self.error_message = "Report was not generated for sending. Try re-running generation."
+            raise tornado.web.HTTPError(status_code = status_code)
         zipf.close()
 
         self.set_header('Content-Type', 'application/zip')

--- a/app/handlers/testConfig.py
+++ b/app/handlers/testConfig.py
@@ -71,10 +71,18 @@ class TestConfigHandler(BaseHandler):
             raise tornado.web.HTTPError(status_code=status_code)
 
     def get(self):
-        # TODO status check that post is done
-        
+        status = StatusHelper.get_status(self.identifier)
+        if test_flag == "feature":
+            if status[Status.Type.FEATURE_TEST] != Status.Flag.COMPLETE:
+                status_code = 500
+                self.error_message = "Feature test not complete, try re-running it."
+                raise tornado.web.HTTPError(status_code = status_code)
+        elif test_flag == "object":
+            if status[Status.Type.OBJECT_TEST] != Status.Flag.COMPLETE:
+                status_code = 500
+                self.error_message = "Object test not complete, try re-running it."
+                raise tornado.web.HTTPError(status_code = status_code)
 
-        # TODO send over video stuff
         identifier = self.get_body_argument('identifier')
         project_path = get_project_path(identifier)
         self.file_name = os.path.join(project_path, 'video.avi') # TODO not test video filename

--- a/app/handlers/testConfig.py
+++ b/app/handlers/testConfig.py
@@ -85,7 +85,7 @@ class TestConfigHandler(BaseHandler):
 
         identifier = self.get_body_argument('identifier')
         project_path = get_project_path(identifier)
-        self.file_name = os.path.join(project_path, 'video.avi') # TODO not test video filename
+        self.file_name = os.path.join(project_path, 'feature_video', 'feature_video.mp4')
 
         self.set_header('Content-Type', 'application/octet-stream')
         self.set_header('Content-Description', 'File Transfer')

--- a/app/handlers/testConfig.py
+++ b/app/handlers/testConfig.py
@@ -32,37 +32,34 @@ class TestConfigHandler(BaseHandler):
     """
 
     def prepare(self):
-        identifier = self.get_body_argument("identifier")
-        test_flag = self.get_body_argument("test_flag")
-        if test_flag == "feature":
+        self.identifier = self.get_body_argument("identifier")
+        self.test_flag = self.get_body_argument("test_flag")
+        if self.test_flag == "feature":
             status_type = Status.Type.FEATURE_TEST
-            if StatusHelper.get_status(identifier)[Status.Type.CONFIG_HOMOGRAPHY] != Status.Flag.COMPLETE:
+            if StatusHelper.get_status(self.identifier)[Status.Type.CONFIG_HOMOGRAPHY] != Status.Flag.COMPLETE:
                 self.error_message = "Uploading homography did not complete successfully, try re-running it."
                 status_code = 412
                 raise tornado.web.HTTPError(status_code = status_code)
-        elif test_flag == "object":
+        elif self.test_flag == "object":
             status_type = Status.Type.OBJECT_TEST
-            if StatusHelper.get_status(identifier)[Status.Type.FEATURE_TEST] != Status.Flag.COMPLETE:
+            if StatusHelper.get_status(self.identifier)[Status.Type.FEATURE_TEST] != Status.Flag.COMPLETE:
                 self.error_message = "Feature testing did not complete successfully, try re-running it."
                 status_code = 412
                 raise tornado.web.HTTPError(status_code = status_code)
-        if StatusHelper.get_status(identifier)[Status.Type.FEATURE_TEST] == Status.Flag.IN_PROGRESS or StatusHelper.get_status(identifier)[Status.Type.OBJECT_TEST] == Status.Flag.IN_PROGRESS:
+        if StatusHelper.get_status(self.identifier)[Status.Type.FEATURE_TEST] == Status.Flag.IN_PROGRESS or StatusHelper.get_status(self.identifier)[Status.Type.OBJECT_TEST] == Status.Flag.IN_PROGRESS:
             status_code = 423
             self.error_message = "Currently running a test. Please wait."
             raise tornado.web.HTTPError(status_code = status_code)
 
-        StatusHelper.set_status(identifier, status_type, Status.Flag.IN_PROGRESS)
+        StatusHelper.set_status(self.identifier, status_type, Status.Flag.IN_PROGRESS)
 
     def post(self):
-        identifier = self.get_body_argument("identifier")
-        test_flag = self.get_body_argument("test_flag")
-
         frame_start = int(self.get_body_argument("frame_start", default = 0))
         num_frames = int(self.get_body_argument("num_frames", default = 120))
         if num_frames > 200:
             num_frames = 200
 
-        status_code, reason = TestConfigHandler.handler(identifier, frame_start, num_frames, test_flag)
+        status_code, reason = TestConfigHandler.handler(self.identifier, frame_start, num_frames, self.test_flag)
 
         if status_code == 200:
             self.finish("Testing tracking")
@@ -72,12 +69,12 @@ class TestConfigHandler(BaseHandler):
 
     def get(self):
         status = StatusHelper.get_status(self.identifier)
-        if test_flag == "feature":
+        if self.test_flag == "feature":
             if status[Status.Type.FEATURE_TEST] != Status.Flag.COMPLETE:
                 status_code = 500
                 self.error_message = "Feature test not complete, try re-running it."
                 raise tornado.web.HTTPError(status_code = status_code)
-        elif test_flag == "object":
+        elif self.test_flag == "object":
             if status[Status.Type.OBJECT_TEST] != Status.Flag.COMPLETE:
                 status_code = 500
                 self.error_message = "Object test not complete, try re-running it."

--- a/app/handlers/testConfig.py
+++ b/app/handlers/testConfig.py
@@ -30,7 +30,7 @@ class TestConfigHandler(BaseHandler):
 
     @apiError error_message The error message to display.
     """
-    
+
     def prepare(self):
         identifier = self.get_body_argument("identifier")
         test_flag = self.get_body_argument("test_flag")
@@ -50,7 +50,7 @@ class TestConfigHandler(BaseHandler):
             status_code = 423
             self.error_message = "Currently running a test. Please wait."
             raise tornado.web.HTTPError(status_code = status_code)
-        
+
         StatusHelper.set_status(identifier, status_type, Status.Flag.IN_PROGRESS)
 
     def post(self):
@@ -69,6 +69,21 @@ class TestConfigHandler(BaseHandler):
         else:
             self.error_message = reason
             raise tornado.web.HTTPError(status_code=status_code)
+
+    def get(self):
+        # TODO status check that post is done
+        
+
+        # TODO send over video stuff
+        identifier = self.get_body_argument('identifier')
+        project_path = get_project_path(identifier)
+        self.file_name = os.path.join(project_path, 'video.avi') # TODO not test video filename
+
+        self.set_header('Content-Type', 'application/octet-stream')
+        self.set_header('Content-Description', 'File Transfer')
+        self.set_header('Content-Disposition', 'attachment; filename=' + self.file_name)
+        self.write_file_stream(self.file_name)
+        self.finish()
 
     @staticmethod
     def handler(identifier, frame_start, num_frames, test_flag):
@@ -204,6 +219,3 @@ class TestConfigObjectThread(threading.Thread):
 
         StatusHelper.set_status(self.identifier, Status.Type.OBJECT_TEST, Status.Flag.COMPLETE)
         return self.callback(200, "Test config done", self.identifier)
-
-
-


### PR DESCRIPTION
Includes a check that the report was generated before attempting to send it (in retrieveResults, this previously broke things ungracefully) and checks that test object/feature have run before sending back a video file (which is currently set to the wrong value).