### PR TITLE
Rm speed CDF, replaced w/ speed Distribution

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -37,7 +37,7 @@ from handlers.status import StatusHandler
 from handlers.createHighlightVideo import CreateHighlightVideoHandler
 from handlers.makeReport import MakeReportHandler
 from handlers.roadUserCounts import RoadUserCountsHandler
-from handlers.createSpeedCDF import CreateSpeedCDFHandler
+from handlers.createSpeedDistribution import CreateSpeedDistributionHandler
 from handlers.retrieveResults import RetrieveResultsHandler
 from handlers.createHighlightVideo import CreateHighlightVideoHandler
 
@@ -61,7 +61,7 @@ class Application(tornado.web.Application):
             (r"/highlightVideo", CreateHighlightVideoHandler),
             (r"/makeReport", MakeReportHandler),
             (r"/roadUserCounts", RoadUserCountsHandler),
-            (r"/speedCDF", CreateSpeedCDFHandler),
+            (r"/speedDistribution", CreateSpeedDistributionHandler),
             (r"/retrieveResults", RetrieveResultsHandler)
 
         ]

--- a/app/handlers/configHomography.py
+++ b/app/handlers/configHomography.py
@@ -19,8 +19,8 @@ class ConfigHomographyHandler(BaseHandler):
 
     @apiParam {String} identifier The identifier of the project for which to configure the homography.
     @apiParam {Integer} unit_pixel_ratio The unit_pixel_ratio of the images (ie. 0.05 meters per pixel).
-    @apiParam {JSON Array} aerial_pts A JSON array containing the coordinates of point clicks on the aerial image as arrays in the form [x_coord, y_coord]
-    @apiParam {JSON Array} camera_pts A JSON array containing the coordinates of point clicks on the camera image as arrays in the form [x_coord, y_coord]
+    @apiParam {JSON} aerial_pts A JSON array containing the coordinates of point clicks on the aerial image as arrays in the form [x_coord, y_coord]
+    @apiParam {JSON} camera_pts A JSON array containing the coordinates of point clicks on the camera image as arrays in the form [x_coord, y_coord]
 
     @apiSuccess status_code The API will return a status code of 200 upon success.
 

--- a/app/handlers/createSpeedDistribution.py
+++ b/app/handlers/createSpeedDistribution.py
@@ -16,9 +16,9 @@ class CreateSpeedDistributionHandler(BaseHandler):
     @apiName SpeedDistribution
     @apiVersion 0.1.0
     @apiGroup Results
-    @apiDescription Calling this route will create a graph of the speed Distribution's from a specified project.
+    @apiDescription Calling this route will create a graph of the speed distribution from a specified project.
 
-    @apiParam {String} identifier The identifier of the project to create a speed Distribution for.
+    @apiParam {String} identifier The identifier of the project to create a speed distribution for.
     @apiParam {Integer} [speed_limit] speed limit of the intersection. Defaults to 25 mph.
     @apiParam {Boolean} [vehicle_only] Flag for specifying only vehicle speeds
 

--- a/app/handlers/createSpeedDistribution.py
+++ b/app/handlers/createSpeedDistribution.py
@@ -5,20 +5,20 @@ import tornado.web
 from baseHandler import BaseHandler
 from traffic_cloud_utils.app_config import get_project_path, get_project_video_path
 from traffic_cloud_utils.video import get_framerate
-from traffic_cloud_utils.plotting.visualization import vel_cdf
+from traffic_cloud_utils.plotting.visualization import vel_distribution
 
 import json
 import traceback
 
-class CreateSpeedCDFHandler(BaseHandler):
+class CreateSpeedDistributionHandler(BaseHandler):
     """
-    @api {post} /speedCDF/ Speed CDF
-    @apiName SpeedCDF
+    @api {post} /speedDistribution/ Speed Distribution
+    @apiName SpeedDistribution
     @apiVersion 0.1.0
     @apiGroup Results
-    @apiDescription Calling this route will create a graph of the speed CDF's from a specified project.
+    @apiDescription Calling this route will create a graph of the speed Distribution's from a specified project.
 
-    @apiParam {String} identifier The identifier of the project to create a speed CDF for.
+    @apiParam {String} identifier The identifier of the project to create a speed Distribution for.
     @apiParam {Integer} [speed_limit] speed limit of the intersection. Defaults to 25 mph.
     @apiParam {Boolean} [vehicle_only] Flag for specifying only vehicle speeds
 
@@ -30,9 +30,9 @@ class CreateSpeedCDFHandler(BaseHandler):
         identifier = self.get_body_argument('identifier')
         speed_limit = int(self.get_body_argument('speed_limit', default=25))
         vehicle_only = bool(self.get_body_argument('vehicle_only', default=True))
-        status_code, reason = CreateSpeedCDFHandler.handler(identifier, speed_limit, vehicle_only)
+        status_code, reason = CreateSpeedDistributionHandler.handler(identifier, speed_limit, vehicle_only)
         if status_code == 200:
-            self.finish("Create Speed CDF")
+            self.finish("Create Speed Distribution")
         else:
             raise tornado.web.HTTPError(reason=reason, status_code=status_code)
 
@@ -54,6 +54,6 @@ class CreateSpeedCDFHandler(BaseHandler):
         if not os.path.exists(video_path):
             return (500, 'Source video file does not exist.  Was the video uploaded?')
 
-        vel_cdf(db, float(get_framerate(video_path)), speed_limit, final_images, vehicle_only)
+        vel_distribution(db, float(get_framerate(video_path)), speed_limit, final_images, vehicle_only)
 
         return (200, "Success")

--- a/app/handlers/makeReport.py
+++ b/app/handlers/makeReport.py
@@ -45,7 +45,6 @@ class MakeReportHandler(BaseHandler):
         # Hardcoded image file name order, so that the ordering of visuals in the report is consistent
         image_fns = [
             os.path.join(final_images, 'road_user_icon_counts.jpg'),
-            os.path.join(final_images, 'velocityCDF.jpg'),
             os.path.join(final_images, 'velocityPDF.jpg')
         ]
 

--- a/app/static/apidoc/api_data.js
+++ b/app/static/apidoc/api_data.js
@@ -1,1 +1,988 @@
-define({ "api": [  {    "type": "post",    "url": "/analysis/",    "title": "Analysis",    "name": "Analysis",    "version": "0.1.0",    "group": "Analysis",    "description": "<p>Calling this route will perform analysis on the video. When the analysis is done, an email will be sent to the project's user. This test consists of running object tracking on the video, and then running safety analysis on the results of the object tracking. When the analysis is complete, the system will produce a safety report for the intersection. (Due to the potentially long duration of testing, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project to test configuration of.</p>"          },          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "email",            "description": "<p>The email address that should be notified when the analysis is complete.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "status_code",            "description": "<p>The API will return a status code of 200 upon success.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/analysis.py",    "groupTitle": "Analysis"  },  {    "type": "post",    "url": "/objectTracking/",    "title": "Object Tracking",    "name": "ObjectTracking",    "version": "0.1.0",    "group": "Analysis",    "description": "<p>Calling this route will perform object tracking on the video. When the analysis is done, an email will be sent to the project's user. (Due to the potentially long run duration, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project on which to run object tracking.</p>"          },          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "email",            "description": "<p>The email address that should be notified when the object tracking is complete.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "status_code",            "description": "<p>The API will return a status code of 200 upon success.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/objectTracking.py",    "groupTitle": "Analysis"  },  {    "type": "post",    "url": "/safetyAnalysis/",    "title": "Safety Analysis",    "name": "SafetyAnalysis",    "version": "0.1.0",    "group": "Analysis",    "description": "<p>Calling this route will perform safety analysis on a project that object tracking has already been run on. When the analysis is done, an email will be sent to the project's user. (Due to the potentially long run duration, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project on which to run safety analysis.</p>"          },          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "email",            "description": "<p>The email address that should be notified when the safety analysis is complete</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "status_code",            "description": "<p>The API will return a status code of 200 upon success.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display. (Will return unique error message if object tracking has NOT been run on specified project)</p>"          }        ]      }    },    "filename": "app/handlers/safetyAnalysis.py",    "groupTitle": "Analysis"  },  {    "type": "post",    "url": "/config/",    "title": "Configure Project",    "name": "Configure_Project",    "version": "0.1.0",    "group": "Configuration",    "description": "<p>Calling this route will modify a specified configuration file using values of the provided arguments.</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project whose configuration files are to be modified.</p>"          },          {            "group": "Parameter",            "type": "Integer",            "optional": true,            "field": "max_features_per_frame",            "description": "<p>This is the maximum number of features to track per frame. If not provided, a value of 1000 will be used. The recommended value for this is 1000 or greater.</p>"          },          {            "group": "Parameter",            "type": "Integer",            "optional": true,            "field": "num_displacement_frames",            "description": "<p>This parameter determines how long features will be tracked. If not provided, a value of 10 will be used. The recommended value for this is 2-15.</p>"          },          {            "group": "Parameter",            "type": "Number",            "optional": true,            "field": "min_feature_displacement",            "description": "<p>This is the displacement needed to track a feature. If not provided, a value of 0.0001 will be used. The recommended value for this is 0.0001-0.1.</p>"          },          {            "group": "Parameter",            "type": "Integer",            "optional": true,            "field": "max_iterations_to_persist",            "description": "<p>This is the maximum number of iterations that an unmoving feature should persist. If not provided, a value of 200 will be used. The recommended value for this is 10-1000.</p>"          },          {            "group": "Parameter",            "type": "Integer",            "optional": true,            "field": "min_feature_frames",            "description": "<p>This is the minimum number of frames that a feature must persist in order to be considered a feature. If not provided, a value of 15 will be used. The recommended value for this is 10-25.</p>"          },          {            "group": "Parameter",            "type": "Number",            "optional": true,            "field": "max_connection_distance",            "description": "<p>This is the maximum distance that two features can be apart and still be considered part of the same object. If not provided, a value of 1 will be used.</p>"          },          {            "group": "Parameter",            "type": "Number",            "optional": true,            "field": "max_segmentation_distance",            "description": "<p>This is the maximum distance that two features that are moving relative to each other can be apart and still be considered part of the same object. If not provided, a value of .7 will be used.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "status_code",            "description": "<p>The API will return a status code of 200 upon success.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/config.py",    "groupTitle": "Configuration"  },  {    "type": "get",    "url": "/defaultConfig/",    "title": "Default Configuration",    "name": "Default_Configuration",    "version": "0.1.0",    "group": "Configuration",    "description": "<p>Calling this route will return the default values for the configuration files used by the server. This is useful if you want to display the values of the configuration parameters to the user, without hardcoding the values and potentially being incorrect if default values on the server change.</p>",    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "Integer",            "optional": false,            "field": "max_features_per_frame",            "description": "<p>This is the maximum number of features to track per frame.</p>"          },          {            "group": "Success 200",            "type": "Integer",            "optional": false,            "field": "num_displacement_frames",            "description": "<p>This parameter determines how long features will be tracked.</p>"          },          {            "group": "Success 200",            "type": "Number",            "optional": false,            "field": "min_feature_displacement",            "description": "<p>This is the displacement needed to track a feature.</p>"          },          {            "group": "Success 200",            "type": "Integer",            "optional": false,            "field": "max_iterations_to_persist",            "description": "<p>This is the maximum number of iterations that an unmoving feature should persist.</p>"          },          {            "group": "Success 200",            "type": "Integer",            "optional": false,            "field": "min_feature_frames",            "description": "<p>This is the minimum number of frames that a feature must persist in order to be considered a feature.</p>"          },          {            "group": "Success 200",            "type": "Number",            "optional": false,            "field": "max_connection_distance",            "description": "<p>This is the maximum distance that two features can be apart and still be considered part of the same object.</p>"          },          {            "group": "Success 200",            "type": "Number",            "optional": false,            "field": "max_segmentation_distance",            "description": "<p>This is the maximum distance that two features that are moving relative to each other can be apart and still be considered part of the same object.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/defaultConfig.py",    "groupTitle": "Configuration"  },  {    "type": "post",    "url": "/testConfig/",    "title": "Test Configuration",    "name": "TestConfig",    "version": "0.1.0",    "group": "Configuration",    "description": "<p>Calling this route will test the video's configuration. This test consists of running object tracking on a small subset of the video, and producing a video showing the results of the tracking. (Due to the potentially long duration of testing, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "test_flag",            "description": "<p>Flag to determine whether feature tracking or object tracking will be tested.</p>"          },          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project to test configuration of.</p>"          },          {            "group": "Parameter",            "type": "Integer",            "optional": true,            "field": "frame_start",            "description": "<p>The frame number to start the configuration test at. If no frame_start is provided, the configuration test will start at the beginning of the video.</p>"          },          {            "group": "Parameter",            "type": "Integer",            "optional": true,            "field": "num_frames",            "description": "<p>The number of frames to analyze. To keep configuration testing short, this parameter must be less than 200. If no num_frames is provided, a default value of 100 will be used.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "status_code",            "description": "<p>The API will return a status code of 200 upon success.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/testConfig.py",    "groupTitle": "Configuration"  },  {    "type": "post",    "url": "/highlightVideo/",    "title": "Highlight Video",    "name": "HighlightVideo",    "version": "0.1.0",    "group": "Results",    "description": "<p>Calling this route will create a highlight video of dangerous interactions from a specified project. When the video is created, an email will be sent to the project's user. This route requires running object tracking on the video, and then running safety analysis on the results of the object tracking beforehand. (Due to the potentially long duration, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project to create a highlight video for.</p>"          },          {            "group": "Parameter",            "type": "Float",            "optional": true,            "field": "ttc_threshold",            "description": "<p>Threshold for determining whether an interaction is dangerous. Default 1.5 seconds.</p>"          },          {            "group": "Parameter",            "type": "Integer",            "optional": true,            "field": "vehicle_only",            "description": "<p>Flag for specifying only vehicle-vehicle interactions. Default to True.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "status_code",            "description": "<p>The API will return a status code of 200 upon success.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/createHighlightVideo.py",    "groupTitle": "Results"  },  {    "type": "post",    "url": "/makeReport/",    "title": "Make Report",    "name": "MakeReport",    "version": "0.1.0",    "group": "Results",    "description": "<p>Calling this route will create a safety report for a specified project. When the report is created, an email will be sent to the project's user. This route requires running object tracking on the video, and then running safety analysis on the results of the object tracking beforehand. (Due to the potentially long duration, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project for which to create the report.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "status_code",            "description": "<p>The API will return a status code of 200 upon success.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/makeReport.py",    "groupTitle": "Results"  },  {    "type": "get",    "url": "/retrieveResults/",    "title": "Retrieve Results",    "name": "RetrieveResults",    "version": "0.0.0",    "group": "Results",    "description": "<p>This route will retrieve any metadata associated with the project. This includes test video files and safety analysis results.</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project to retrieve results from.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "files",            "description": "<p>The API will return all metadata since last retrieval as a compressed archive.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/retrieveResults.py",    "groupTitle": "Results"  },  {    "type": "post",    "url": "/roadUserCounts/",    "title": "Road User Counts",    "name": "RoadUserCounts",    "version": "0.1.0",    "group": "Results",    "description": "<p>Calling this route will create a road user counts image from a specified project. When the image is created, an email will be sent to the project's user. This route requires running object tracking on the video, and then running safety analysis on the results of the object tracking beforehand. (Due to the potentially long duration, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project to create road user counts for.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "status_code",            "description": "<p>The API will return a status code of 200 upon success.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/roadUserCounts.py",    "groupTitle": "Results"  },  {    "type": "post",    "url": "/speedCDF/",    "title": "Speed CDF",    "name": "SpeedCDF",    "version": "0.1.0",    "group": "Results",    "description": "<p>Calling this route will create a graph of the speed CDF's from a specified project.</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project to create a speed CDF for.</p>"          },          {            "group": "Parameter",            "type": "Integer",            "optional": true,            "field": "speed_limit",            "description": "<p>speed limit of the intersection. Defaults to 25 mph.</p>"          },          {            "group": "Parameter",            "type": "Boolean",            "optional": true,            "field": "vehicle_only",            "description": "<p>Flag for specifying only vehicle speeds</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "status_code",            "description": "<p>The API will return a status code of 200 upon success.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/createSpeedCDF.py",    "groupTitle": "Results"  },  {    "type": "post",    "url": "/status/",    "title": "Processing Status",    "name": "ProcessingStatus",    "version": "0.1.0",    "group": "Status",    "description": "<p>Calling this route will return the current status of any long-running processing that your project can perform, is performing or has performed. It returns a field for each possible long-running process whose value can be 0, 1 or 2. A status of 0 for a given field means that that type of processing has not been run on this project. A status of 1 means that that type of processing is currently running for this process. A status of 2 means that the type of processing has been completed for this project. You can poll this endpoint in order to know the status of processing so that you may call the next API call, such as returning results or performing subsequent analysis.</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project on which to return status information.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "upload_homography",            "description": "<p>The status of homography file uploading.</p>"          },          {            "group": "Success 200",            "optional": false,            "field": "configuration_test",            "description": "<p>The status of the configuration test.</p>"          },          {            "group": "Success 200",            "optional": false,            "field": "object_tracking",            "description": "<p>The status of object tracking.</p>"          },          {            "group": "Success 200",            "optional": false,            "field": "safety_analysis",            "description": "<p>The status of performing safety analysis.</p>"          },          {            "group": "Success 200",            "optional": false,            "field": "highlight_video",            "description": "<p>The status of creating the highlight video.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display. (Will return unique error message if object tracking has NOT been run on specified project)</p>"          }        ]      }    },    "filename": "app/handlers/status.py",    "groupTitle": "Status"  },  {    "type": "post",    "url": "/configHomography/",    "title": "Config Homography",    "name": "ConfigHomography",    "version": "0.2.0",    "group": "Upload",    "description": "<p>Use this route to upload homography data for a project.</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project for which to configure the homography.</p>"          },          {            "group": "Parameter",            "type": "Integer",            "optional": false,            "field": "unit_pixel_ratio",            "description": "<p>The unit_pixel_ratio of the images (ie. 0.05 meters per pixel).</p>"          },          {            "group": "Parameter",            "type": "JSON",            "optional": false,            "field": "aerial_pts",            "description": "<p>A JSON array containing the coordinates of point clicks on the aerial image as arrays in the form [x_coord, y_coord]</p>"          },          {            "group": "Parameter",            "type": "JSON",            "optional": false,            "field": "camera_pts",            "description": "<p>A JSON array containing the coordinates of point clicks on the camera image as arrays in the form [x_coord, y_coord]</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "status_code",            "description": "<p>The API will return a status code of 200 upon success.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/configHomography.py",    "groupTitle": "Upload"  },  {    "type": "post",    "url": "/upload/",    "title": "Upload Files",    "name": "UploadFiles",    "version": "0.1.0",    "group": "Upload",    "description": "<p>This route will upload files to a project (and create a new project if an old one is not specified). You may provide a project identifier if you would like to update the files from an old project. If you provide a project identifier for an old project, all of the parameters are optional. If you are creating a new project, all parameters are required. This route will always return a dictionary containing the project identifier.</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "email",            "description": "<p>The email to notify when analysis is done.</p>"          },          {            "group": "Parameter",            "type": "String",            "optional": true,            "field": "identifier",            "description": "<p>The identifier of the project to update the file of. If no identifier is provided, a new project will be created, and the identifier will be returned in the response.</p>"          },          {            "group": "Parameter",            "type": "File",            "optional": false,            "field": "homography/aerialpng",            "description": "<p>An aerial photo of the intersection.</p>"          },          {            "group": "Parameter",            "type": "File",            "optional": false,            "field": "homography/camerapng",            "description": "<p>A screenshot of the intersection from the video.</p>"          },          {            "group": "Parameter",            "type": "File",            "optional": false,            "field": "homography/homographytxt",            "description": "<p>The homography text file to use.</p>"          },          {            "group": "Parameter",            "type": "File",            "optional": false,            "field": "project_namecfg",            "description": "<p>The project name configuration file.</p>"          },          {            "group": "Parameter",            "type": "File",            "optional": false,            "field": "trackingcfg",            "description": "<p>The tracking configuration file.</p>"          },          {            "group": "Parameter",            "type": "File",            "optional": false,            "field": "temp/test/test_object/object_trackingcfg",            "description": "<p>The object tracking configuration file.</p>"          },          {            "group": "Parameter",            "type": "File",            "optional": false,            "field": "temp/test/test_feature/feature_trackingcfg",            "description": "<p>The feature tracking configuration file.</p>"          },          {            "group": "Parameter",            "type": "File",            "optional": false,            "field": "video",            "description": "<p>The video file to analyze. This can have any file extension.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "project_identifier",            "description": "<p>The project identifier. This will be used to reference the project in all other requests.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/upload.py",    "groupTitle": "Upload"  },  {    "type": "post",    "url": "/uploadVideo/",    "title": "Upload Video",    "name": "UploadVideo",    "version": "0.1.0",    "group": "Upload",    "description": "<p>This route will upload a video to a project (and create a new project if an old one is not specified)</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "File",            "optional": false,            "field": "video",            "description": "<p>The video file to analyze. This can have any file extension.</p>"          },          {            "group": "Parameter",            "type": "String",            "optional": true,            "field": "identifier",            "description": "<p>The identifier of the project to update the video of. If no identifier is provided, a new project will be created, and the identifier will be returned in the response.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "project_identifier",            "description": "<p>The project identifier. This will be used to reference the project in all other requests.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/uploadVideo.py",    "groupTitle": "Upload"  }] });
+define({ "api": [
+  {
+    "type": "post",
+    "url": "/analysis/",
+    "title": "Analysis",
+    "name": "Analysis",
+    "version": "0.1.0",
+    "group": "Analysis",
+    "description": "<p>Calling this route will perform analysis on the video. When the analysis is done, an email will be sent to the project's user. This test consists of running object tracking on the video, and then running safety analysis on the results of the object tracking. When the analysis is complete, the system will produce a safety report for the intersection. (Due to the potentially long duration of testing, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project to test configuration of.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "email",
+            "description": "<p>The email address that should be notified when the analysis is complete.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "status_code",
+            "description": "<p>The API will return a status code of 200 upon success.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/analysis.py",
+    "groupTitle": "Analysis"
+  },
+  {
+    "type": "post",
+    "url": "/objectTracking/",
+    "title": "Object Tracking",
+    "name": "ObjectTracking",
+    "version": "0.1.0",
+    "group": "Analysis",
+    "description": "<p>Calling this route will perform object tracking on the video. When the analysis is done, an email will be sent to the project's user. (Due to the potentially long run duration, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project on which to run object tracking.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "email",
+            "description": "<p>The email address that should be notified when the object tracking is complete.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "status_code",
+            "description": "<p>The API will return a status code of 200 upon success.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/objectTracking.py",
+    "groupTitle": "Analysis"
+  },
+  {
+    "type": "post",
+    "url": "/safetyAnalysis/",
+    "title": "Safety Analysis",
+    "name": "SafetyAnalysis",
+    "version": "0.1.0",
+    "group": "Analysis",
+    "description": "<p>Calling this route will perform safety analysis on a project that object tracking has already been run on. When the analysis is done, an email will be sent to the project's user. (Due to the potentially long run duration, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project on which to run safety analysis.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "email",
+            "description": "<p>The email address that should be notified when the safety analysis is complete</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "status_code",
+            "description": "<p>The API will return a status code of 200 upon success.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display. (Will return unique error message if object tracking has NOT been run on specified project)</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/safetyAnalysis.py",
+    "groupTitle": "Analysis"
+  },
+  {
+    "type": "post",
+    "url": "/configHomography/",
+    "title": "Config Homography",
+    "name": "ConfigHomography",
+    "version": "0.2.0",
+    "group": "Configuration",
+    "description": "<p>Use this route to upload homography data for a project.</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project for which to configure the homography.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": false,
+            "field": "unit_pixel_ratio",
+            "description": "<p>The unit_pixel_ratio of the images (ie. 0.05 meters per pixel).</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "JSON",
+            "optional": false,
+            "field": "aerial_pts",
+            "description": "<p>A JSON array containing the coordinates of point clicks on the aerial image as arrays in the form [x_coord, y_coord]</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "JSON",
+            "optional": false,
+            "field": "camera_pts",
+            "description": "<p>A JSON array containing the coordinates of point clicks on the camera image as arrays in the form [x_coord, y_coord]</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "status_code",
+            "description": "<p>The API will return a status code of 200 upon success.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/configHomography.py",
+    "groupTitle": "Configuration"
+  },
+  {
+    "type": "post",
+    "url": "/config/",
+    "title": "Configure Project",
+    "name": "Configure_Project",
+    "version": "0.1.0",
+    "group": "Configuration",
+    "description": "<p>Calling this route will modify a specified configuration file using values of the provided arguments.</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project whose configuration files are to be modified.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": true,
+            "field": "max_features_per_frame",
+            "description": "<p>This is the maximum number of features to track per frame. If not provided, a value of 1000 will be used. The recommended value for this is 1000 or greater.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": true,
+            "field": "num_displacement_frames",
+            "description": "<p>This parameter determines how long features will be tracked. If not provided, a value of 10 will be used. The recommended value for this is 2-15.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Number",
+            "optional": true,
+            "field": "min_feature_displacement",
+            "description": "<p>This is the displacement needed to track a feature. If not provided, a value of 0.0001 will be used. The recommended value for this is 0.0001-0.1.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": true,
+            "field": "max_iterations_to_persist",
+            "description": "<p>This is the maximum number of iterations that an unmoving feature should persist. If not provided, a value of 200 will be used. The recommended value for this is 10-1000.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": true,
+            "field": "min_feature_frames",
+            "description": "<p>This is the minimum number of frames that a feature must persist in order to be considered a feature. If not provided, a value of 15 will be used. The recommended value for this is 10-25.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Number",
+            "optional": true,
+            "field": "max_connection_distance",
+            "description": "<p>This is the maximum distance that two features can be apart and still be considered part of the same object. If not provided, a value of 1 will be used.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Number",
+            "optional": true,
+            "field": "max_segmentation_distance",
+            "description": "<p>This is the maximum distance that two features that are moving relative to each other can be apart and still be considered part of the same object. If not provided, a value of .7 will be used.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "status_code",
+            "description": "<p>The API will return a status code of 200 upon success.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/config.py",
+    "groupTitle": "Configuration"
+  },
+  {
+    "type": "get",
+    "url": "/defaultConfig/",
+    "title": "Default Configuration",
+    "name": "Default_Configuration",
+    "version": "0.1.0",
+    "group": "Configuration",
+    "description": "<p>Calling this route will return the default values for the configuration files used by the server. This is useful if you want to display the values of the configuration parameters to the user, without hardcoding the values and potentially being incorrect if default values on the server change.</p>",
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "Integer",
+            "optional": false,
+            "field": "max_features_per_frame",
+            "description": "<p>This is the maximum number of features to track per frame.</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Integer",
+            "optional": false,
+            "field": "num_displacement_frames",
+            "description": "<p>This parameter determines how long features will be tracked.</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Number",
+            "optional": false,
+            "field": "min_feature_displacement",
+            "description": "<p>This is the displacement needed to track a feature.</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Integer",
+            "optional": false,
+            "field": "max_iterations_to_persist",
+            "description": "<p>This is the maximum number of iterations that an unmoving feature should persist.</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Integer",
+            "optional": false,
+            "field": "min_feature_frames",
+            "description": "<p>This is the minimum number of frames that a feature must persist in order to be considered a feature.</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Number",
+            "optional": false,
+            "field": "max_connection_distance",
+            "description": "<p>This is the maximum distance that two features can be apart and still be considered part of the same object.</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Number",
+            "optional": false,
+            "field": "max_segmentation_distance",
+            "description": "<p>This is the maximum distance that two features that are moving relative to each other can be apart and still be considered part of the same object.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/defaultConfig.py",
+    "groupTitle": "Configuration"
+  },
+  {
+    "type": "post",
+    "url": "/testConfig/",
+    "title": "Test Configuration",
+    "name": "TestConfig",
+    "version": "0.1.0",
+    "group": "Configuration",
+    "description": "<p>Calling this route will test the video's configuration. This test consists of running object tracking on a small subset of the video, and producing a video showing the results of the tracking. (Due to the potentially long duration of testing, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "test_flag",
+            "description": "<p>Flag to determine whether feature tracking or object tracking will be tested.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project to test configuration of.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": true,
+            "field": "frame_start",
+            "description": "<p>The frame number to start the configuration test at. If no frame_start is provided, the configuration test will start at the beginning of the video.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": true,
+            "field": "num_frames",
+            "description": "<p>The number of frames to analyze. To keep configuration testing short, this parameter must be less than 200. If no num_frames is provided, a default value of 100 will be used.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "status_code",
+            "description": "<p>The API will return a status code of 200 upon success.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/testConfig.py",
+    "groupTitle": "Configuration"
+  },
+  {
+    "type": "post",
+    "url": "/highlightVideo/",
+    "title": "Highlight Video",
+    "name": "HighlightVideo",
+    "version": "0.1.0",
+    "group": "Results",
+    "description": "<p>Calling this route will create a highlight video of dangerous interactions from a specified project. When the video is created, an email will be sent to the project's user. This route requires running object tracking on the video, and then running safety analysis on the results of the object tracking beforehand. (Due to the potentially long duration, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project to create a highlight video for.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Float",
+            "optional": true,
+            "field": "ttc_threshold",
+            "description": "<p>Threshold for determining whether an interaction is dangerous. Default 1.5 seconds.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": true,
+            "field": "vehicle_only",
+            "description": "<p>Flag for specifying only vehicle-vehicle interactions. Default to True.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "status_code",
+            "description": "<p>The API will return a status code of 200 upon success.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/createHighlightVideo.py",
+    "groupTitle": "Results"
+  },
+  {
+    "type": "post",
+    "url": "/makeReport/",
+    "title": "Make Report",
+    "name": "MakeReport",
+    "version": "0.1.0",
+    "group": "Results",
+    "description": "<p>Calling this route will create a safety report for a specified project. When the report is created, an email will be sent to the project's user. This route requires running object tracking on the video, and then running safety analysis on the results of the object tracking beforehand. (Due to the potentially long duration, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project for which to create the report.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "status_code",
+            "description": "<p>The API will return a status code of 200 upon success.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/makeReport.py",
+    "groupTitle": "Results"
+  },
+  {
+    "type": "get",
+    "url": "/retrieveResults/",
+    "title": "Retrieve Results",
+    "name": "RetrieveResults",
+    "version": "0.0.0",
+    "group": "Results",
+    "description": "<p>This route will retrieve any metadata associated with the project. This includes test video files and safety analysis results.</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project to retrieve results from.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "files",
+            "description": "<p>The API will return all metadata since last retrieval as a compressed archive.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/retrieveResults.py",
+    "groupTitle": "Results"
+  },
+  {
+    "type": "post",
+    "url": "/roadUserCounts/",
+    "title": "Road User Counts",
+    "name": "RoadUserCounts",
+    "version": "0.1.0",
+    "group": "Results",
+    "description": "<p>Calling this route will create a road user counts image from a specified project. When the image is created, an email will be sent to the project's user. This route requires running object tracking on the video, and then running safety analysis on the results of the object tracking beforehand. (Due to the potentially long duration, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project to create road user counts for.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "status_code",
+            "description": "<p>The API will return a status code of 200 upon success.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/roadUserCounts.py",
+    "groupTitle": "Results"
+  },
+  {
+    "type": "post",
+    "url": "/speedDistribution/",
+    "title": "Speed Distribution",
+    "name": "SpeedDistribution",
+    "version": "0.1.0",
+    "group": "Results",
+    "description": "<p>Calling this route will create a graph of the speed distribution from a specified project.</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project to create a speed distribution for.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": true,
+            "field": "speed_limit",
+            "description": "<p>speed limit of the intersection. Defaults to 25 mph.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Boolean",
+            "optional": true,
+            "field": "vehicle_only",
+            "description": "<p>Flag for specifying only vehicle speeds</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "status_code",
+            "description": "<p>The API will return a status code of 200 upon success.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/createSpeedDistribution.py",
+    "groupTitle": "Results"
+  },
+  {
+    "type": "post",
+    "url": "/status/",
+    "title": "Processing Status",
+    "name": "ProcessingStatus",
+    "version": "0.1.0",
+    "group": "Status",
+    "description": "<p>Calling this route will return the current status of any long-running processing that your project can perform, is performing or has performed. It returns a field for each possible long-running process whose value can be 0, 1 or 2. A status of 0 for a given field means that that type of processing has not been run on this project. A status of 1 means that that type of processing is currently running for this process. A status of 2 means that the type of processing has been completed for this project. You can poll this endpoint in order to know the status of processing so that you may call the next API call, such as returning results or performing subsequent analysis.</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project on which to return status information.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "upload_homography",
+            "description": "<p>The status of homography file uploading.</p>"
+          },
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "configuration_test",
+            "description": "<p>The status of the configuration test.</p>"
+          },
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "object_tracking",
+            "description": "<p>The status of object tracking.</p>"
+          },
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "safety_analysis",
+            "description": "<p>The status of performing safety analysis.</p>"
+          },
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "highlight_video",
+            "description": "<p>The status of creating the highlight video.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display. (Will return unique error message if object tracking has NOT been run on specified project)</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/status.py",
+    "groupTitle": "Status"
+  },
+  {
+    "type": "post",
+    "url": "/upload/",
+    "title": "Upload Files",
+    "name": "UploadFiles",
+    "version": "0.1.0",
+    "group": "Upload",
+    "description": "<p>This route will upload files to a project (and create a new project if an old one is not specified). You may provide a project identifier if you would like to update the files from an old project. If you provide a project identifier for an old project, all of the parameters are optional. If you are creating a new project, all parameters are required. This route will always return a dictionary containing the project identifier.</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "email",
+            "description": "<p>The email to notify when analysis is done.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": true,
+            "field": "identifier",
+            "description": "<p>The identifier of the project to update the file of. If no identifier is provided, a new project will be created, and the identifier will be returned in the response.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "File",
+            "optional": false,
+            "field": "homography/aerialpng",
+            "description": "<p>An aerial photo of the intersection.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "File",
+            "optional": false,
+            "field": "homography/camerapng",
+            "description": "<p>A screenshot of the intersection from the video.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "File",
+            "optional": false,
+            "field": "homography/homographytxt",
+            "description": "<p>The homography text file to use.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "File",
+            "optional": false,
+            "field": "project_namecfg",
+            "description": "<p>The project name configuration file.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "File",
+            "optional": false,
+            "field": "trackingcfg",
+            "description": "<p>The tracking configuration file.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "File",
+            "optional": false,
+            "field": "temp/test/test_object/object_trackingcfg",
+            "description": "<p>The object tracking configuration file.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "File",
+            "optional": false,
+            "field": "temp/test/test_feature/feature_trackingcfg",
+            "description": "<p>The feature tracking configuration file.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "File",
+            "optional": false,
+            "field": "video",
+            "description": "<p>The video file to analyze. This can have any file extension.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "String",
+            "optional": false,
+            "field": "project_identifier",
+            "description": "<p>The project identifier. This will be used to reference the project in all other requests.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/upload.py",
+    "groupTitle": "Upload"
+  },
+  {
+    "type": "post",
+    "url": "/uploadVideo/",
+    "title": "Upload Video",
+    "name": "UploadVideo",
+    "version": "0.1.0",
+    "group": "Upload",
+    "description": "<p>This route will upload a video to a project (and create a new project if an old one is not specified)</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "File",
+            "optional": false,
+            "field": "video",
+            "description": "<p>The video file to analyze. This can have any file extension.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": true,
+            "field": "identifier",
+            "description": "<p>The identifier of the project to update the video of. If no identifier is provided, a new project will be created, and the identifier will be returned in the response.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "String",
+            "optional": false,
+            "field": "project_identifier",
+            "description": "<p>The project identifier. This will be used to reference the project in all other requests.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/uploadVideo.py",
+    "groupTitle": "Upload"
+  }
+] });

--- a/app/static/apidoc/api_data.json
+++ b/app/static/apidoc/api_data.json
@@ -1,1 +1,988 @@
-[  {    "type": "post",    "url": "/analysis/",    "title": "Analysis",    "name": "Analysis",    "version": "0.1.0",    "group": "Analysis",    "description": "<p>Calling this route will perform analysis on the video. When the analysis is done, an email will be sent to the project's user. This test consists of running object tracking on the video, and then running safety analysis on the results of the object tracking. When the analysis is complete, the system will produce a safety report for the intersection. (Due to the potentially long duration of testing, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project to test configuration of.</p>"          },          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "email",            "description": "<p>The email address that should be notified when the analysis is complete.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "status_code",            "description": "<p>The API will return a status code of 200 upon success.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/analysis.py",    "groupTitle": "Analysis"  },  {    "type": "post",    "url": "/objectTracking/",    "title": "Object Tracking",    "name": "ObjectTracking",    "version": "0.1.0",    "group": "Analysis",    "description": "<p>Calling this route will perform object tracking on the video. When the analysis is done, an email will be sent to the project's user. (Due to the potentially long run duration, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project on which to run object tracking.</p>"          },          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "email",            "description": "<p>The email address that should be notified when the object tracking is complete.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "status_code",            "description": "<p>The API will return a status code of 200 upon success.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/objectTracking.py",    "groupTitle": "Analysis"  },  {    "type": "post",    "url": "/safetyAnalysis/",    "title": "Safety Analysis",    "name": "SafetyAnalysis",    "version": "0.1.0",    "group": "Analysis",    "description": "<p>Calling this route will perform safety analysis on a project that object tracking has already been run on. When the analysis is done, an email will be sent to the project's user. (Due to the potentially long run duration, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project on which to run safety analysis.</p>"          },          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "email",            "description": "<p>The email address that should be notified when the safety analysis is complete</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "status_code",            "description": "<p>The API will return a status code of 200 upon success.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display. (Will return unique error message if object tracking has NOT been run on specified project)</p>"          }        ]      }    },    "filename": "app/handlers/safetyAnalysis.py",    "groupTitle": "Analysis"  },  {    "type": "post",    "url": "/config/",    "title": "Configure Project",    "name": "Configure_Project",    "version": "0.1.0",    "group": "Configuration",    "description": "<p>Calling this route will modify a specified configuration file using values of the provided arguments.</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project whose configuration files are to be modified.</p>"          },          {            "group": "Parameter",            "type": "Integer",            "optional": true,            "field": "max_features_per_frame",            "description": "<p>This is the maximum number of features to track per frame. If not provided, a value of 1000 will be used. The recommended value for this is 1000 or greater.</p>"          },          {            "group": "Parameter",            "type": "Integer",            "optional": true,            "field": "num_displacement_frames",            "description": "<p>This parameter determines how long features will be tracked. If not provided, a value of 10 will be used. The recommended value for this is 2-15.</p>"          },          {            "group": "Parameter",            "type": "Number",            "optional": true,            "field": "min_feature_displacement",            "description": "<p>This is the displacement needed to track a feature. If not provided, a value of 0.0001 will be used. The recommended value for this is 0.0001-0.1.</p>"          },          {            "group": "Parameter",            "type": "Integer",            "optional": true,            "field": "max_iterations_to_persist",            "description": "<p>This is the maximum number of iterations that an unmoving feature should persist. If not provided, a value of 200 will be used. The recommended value for this is 10-1000.</p>"          },          {            "group": "Parameter",            "type": "Integer",            "optional": true,            "field": "min_feature_frames",            "description": "<p>This is the minimum number of frames that a feature must persist in order to be considered a feature. If not provided, a value of 15 will be used. The recommended value for this is 10-25.</p>"          },          {            "group": "Parameter",            "type": "Number",            "optional": true,            "field": "max_connection_distance",            "description": "<p>This is the maximum distance that two features can be apart and still be considered part of the same object. If not provided, a value of 1 will be used.</p>"          },          {            "group": "Parameter",            "type": "Number",            "optional": true,            "field": "max_segmentation_distance",            "description": "<p>This is the maximum distance that two features that are moving relative to each other can be apart and still be considered part of the same object. If not provided, a value of .7 will be used.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "status_code",            "description": "<p>The API will return a status code of 200 upon success.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/config.py",    "groupTitle": "Configuration"  },  {    "type": "get",    "url": "/defaultConfig/",    "title": "Default Configuration",    "name": "Default_Configuration",    "version": "0.1.0",    "group": "Configuration",    "description": "<p>Calling this route will return the default values for the configuration files used by the server. This is useful if you want to display the values of the configuration parameters to the user, without hardcoding the values and potentially being incorrect if default values on the server change.</p>",    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "Integer",            "optional": false,            "field": "max_features_per_frame",            "description": "<p>This is the maximum number of features to track per frame.</p>"          },          {            "group": "Success 200",            "type": "Integer",            "optional": false,            "field": "num_displacement_frames",            "description": "<p>This parameter determines how long features will be tracked.</p>"          },          {            "group": "Success 200",            "type": "Number",            "optional": false,            "field": "min_feature_displacement",            "description": "<p>This is the displacement needed to track a feature.</p>"          },          {            "group": "Success 200",            "type": "Integer",            "optional": false,            "field": "max_iterations_to_persist",            "description": "<p>This is the maximum number of iterations that an unmoving feature should persist.</p>"          },          {            "group": "Success 200",            "type": "Integer",            "optional": false,            "field": "min_feature_frames",            "description": "<p>This is the minimum number of frames that a feature must persist in order to be considered a feature.</p>"          },          {            "group": "Success 200",            "type": "Number",            "optional": false,            "field": "max_connection_distance",            "description": "<p>This is the maximum distance that two features can be apart and still be considered part of the same object.</p>"          },          {            "group": "Success 200",            "type": "Number",            "optional": false,            "field": "max_segmentation_distance",            "description": "<p>This is the maximum distance that two features that are moving relative to each other can be apart and still be considered part of the same object.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/defaultConfig.py",    "groupTitle": "Configuration"  },  {    "type": "post",    "url": "/testConfig/",    "title": "Test Configuration",    "name": "TestConfig",    "version": "0.1.0",    "group": "Configuration",    "description": "<p>Calling this route will test the video's configuration. This test consists of running object tracking on a small subset of the video, and producing a video showing the results of the tracking. (Due to the potentially long duration of testing, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "test_flag",            "description": "<p>Flag to determine whether feature tracking or object tracking will be tested.</p>"          },          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project to test configuration of.</p>"          },          {            "group": "Parameter",            "type": "Integer",            "optional": true,            "field": "frame_start",            "description": "<p>The frame number to start the configuration test at. If no frame_start is provided, the configuration test will start at the beginning of the video.</p>"          },          {            "group": "Parameter",            "type": "Integer",            "optional": true,            "field": "num_frames",            "description": "<p>The number of frames to analyze. To keep configuration testing short, this parameter must be less than 200. If no num_frames is provided, a default value of 100 will be used.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "status_code",            "description": "<p>The API will return a status code of 200 upon success.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/testConfig.py",    "groupTitle": "Configuration"  },  {    "type": "post",    "url": "/highlightVideo/",    "title": "Highlight Video",    "name": "HighlightVideo",    "version": "0.1.0",    "group": "Results",    "description": "<p>Calling this route will create a highlight video of dangerous interactions from a specified project. When the video is created, an email will be sent to the project's user. This route requires running object tracking on the video, and then running safety analysis on the results of the object tracking beforehand. (Due to the potentially long duration, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project to create a highlight video for.</p>"          },          {            "group": "Parameter",            "type": "Float",            "optional": true,            "field": "ttc_threshold",            "description": "<p>Threshold for determining whether an interaction is dangerous. Default 1.5 seconds.</p>"          },          {            "group": "Parameter",            "type": "Integer",            "optional": true,            "field": "vehicle_only",            "description": "<p>Flag for specifying only vehicle-vehicle interactions. Default to True.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "status_code",            "description": "<p>The API will return a status code of 200 upon success.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/createHighlightVideo.py",    "groupTitle": "Results"  },  {    "type": "post",    "url": "/makeReport/",    "title": "Make Report",    "name": "MakeReport",    "version": "0.1.0",    "group": "Results",    "description": "<p>Calling this route will create a safety report for a specified project. When the report is created, an email will be sent to the project's user. This route requires running object tracking on the video, and then running safety analysis on the results of the object tracking beforehand. (Due to the potentially long duration, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project for which to create the report.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "status_code",            "description": "<p>The API will return a status code of 200 upon success.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/makeReport.py",    "groupTitle": "Results"  },  {    "type": "get",    "url": "/retrieveResults/",    "title": "Retrieve Results",    "name": "RetrieveResults",    "version": "0.0.0",    "group": "Results",    "description": "<p>This route will retrieve any metadata associated with the project. This includes test video files and safety analysis results.</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project to retrieve results from.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "files",            "description": "<p>The API will return all metadata since last retrieval as a compressed archive.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/retrieveResults.py",    "groupTitle": "Results"  },  {    "type": "post",    "url": "/roadUserCounts/",    "title": "Road User Counts",    "name": "RoadUserCounts",    "version": "0.1.0",    "group": "Results",    "description": "<p>Calling this route will create a road user counts image from a specified project. When the image is created, an email will be sent to the project's user. This route requires running object tracking on the video, and then running safety analysis on the results of the object tracking beforehand. (Due to the potentially long duration, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project to create road user counts for.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "status_code",            "description": "<p>The API will return a status code of 200 upon success.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/roadUserCounts.py",    "groupTitle": "Results"  },  {    "type": "post",    "url": "/speedCDF/",    "title": "Speed CDF",    "name": "SpeedCDF",    "version": "0.1.0",    "group": "Results",    "description": "<p>Calling this route will create a graph of the speed CDF's from a specified project.</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project to create a speed CDF for.</p>"          },          {            "group": "Parameter",            "type": "Integer",            "optional": true,            "field": "speed_limit",            "description": "<p>speed limit of the intersection. Defaults to 25 mph.</p>"          },          {            "group": "Parameter",            "type": "Boolean",            "optional": true,            "field": "vehicle_only",            "description": "<p>Flag for specifying only vehicle speeds</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "status_code",            "description": "<p>The API will return a status code of 200 upon success.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/createSpeedCDF.py",    "groupTitle": "Results"  },  {    "type": "post",    "url": "/status/",    "title": "Processing Status",    "name": "ProcessingStatus",    "version": "0.1.0",    "group": "Status",    "description": "<p>Calling this route will return the current status of any long-running processing that your project can perform, is performing or has performed. It returns a field for each possible long-running process whose value can be 0, 1 or 2. A status of 0 for a given field means that that type of processing has not been run on this project. A status of 1 means that that type of processing is currently running for this process. A status of 2 means that the type of processing has been completed for this project. You can poll this endpoint in order to know the status of processing so that you may call the next API call, such as returning results or performing subsequent analysis.</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project on which to return status information.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "upload_homography",            "description": "<p>The status of homography file uploading.</p>"          },          {            "group": "Success 200",            "optional": false,            "field": "configuration_test",            "description": "<p>The status of the configuration test.</p>"          },          {            "group": "Success 200",            "optional": false,            "field": "object_tracking",            "description": "<p>The status of object tracking.</p>"          },          {            "group": "Success 200",            "optional": false,            "field": "safety_analysis",            "description": "<p>The status of performing safety analysis.</p>"          },          {            "group": "Success 200",            "optional": false,            "field": "highlight_video",            "description": "<p>The status of creating the highlight video.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display. (Will return unique error message if object tracking has NOT been run on specified project)</p>"          }        ]      }    },    "filename": "app/handlers/status.py",    "groupTitle": "Status"  },  {    "type": "post",    "url": "/configHomography/",    "title": "Config Homography",    "name": "ConfigHomography",    "version": "0.2.0",    "group": "Upload",    "description": "<p>Use this route to upload homography data for a project.</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "identifier",            "description": "<p>The identifier of the project for which to configure the homography.</p>"          },          {            "group": "Parameter",            "type": "Integer",            "optional": false,            "field": "unit_pixel_ratio",            "description": "<p>The unit_pixel_ratio of the images (ie. 0.05 meters per pixel).</p>"          },          {            "group": "Parameter",            "type": "JSON",            "optional": false,            "field": "aerial_pts",            "description": "<p>A JSON array containing the coordinates of point clicks on the aerial image as arrays in the form [x_coord, y_coord]</p>"          },          {            "group": "Parameter",            "type": "JSON",            "optional": false,            "field": "camera_pts",            "description": "<p>A JSON array containing the coordinates of point clicks on the camera image as arrays in the form [x_coord, y_coord]</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "optional": false,            "field": "status_code",            "description": "<p>The API will return a status code of 200 upon success.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/configHomography.py",    "groupTitle": "Upload"  },  {    "type": "post",    "url": "/upload/",    "title": "Upload Files",    "name": "UploadFiles",    "version": "0.1.0",    "group": "Upload",    "description": "<p>This route will upload files to a project (and create a new project if an old one is not specified). You may provide a project identifier if you would like to update the files from an old project. If you provide a project identifier for an old project, all of the parameters are optional. If you are creating a new project, all parameters are required. This route will always return a dictionary containing the project identifier.</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "email",            "description": "<p>The email to notify when analysis is done.</p>"          },          {            "group": "Parameter",            "type": "String",            "optional": true,            "field": "identifier",            "description": "<p>The identifier of the project to update the file of. If no identifier is provided, a new project will be created, and the identifier will be returned in the response.</p>"          },          {            "group": "Parameter",            "type": "File",            "optional": false,            "field": "homography/aerialpng",            "description": "<p>An aerial photo of the intersection.</p>"          },          {            "group": "Parameter",            "type": "File",            "optional": false,            "field": "homography/camerapng",            "description": "<p>A screenshot of the intersection from the video.</p>"          },          {            "group": "Parameter",            "type": "File",            "optional": false,            "field": "homography/homographytxt",            "description": "<p>The homography text file to use.</p>"          },          {            "group": "Parameter",            "type": "File",            "optional": false,            "field": "project_namecfg",            "description": "<p>The project name configuration file.</p>"          },          {            "group": "Parameter",            "type": "File",            "optional": false,            "field": "trackingcfg",            "description": "<p>The tracking configuration file.</p>"          },          {            "group": "Parameter",            "type": "File",            "optional": false,            "field": "temp/test/test_object/object_trackingcfg",            "description": "<p>The object tracking configuration file.</p>"          },          {            "group": "Parameter",            "type": "File",            "optional": false,            "field": "temp/test/test_feature/feature_trackingcfg",            "description": "<p>The feature tracking configuration file.</p>"          },          {            "group": "Parameter",            "type": "File",            "optional": false,            "field": "video",            "description": "<p>The video file to analyze. This can have any file extension.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "project_identifier",            "description": "<p>The project identifier. This will be used to reference the project in all other requests.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/upload.py",    "groupTitle": "Upload"  },  {    "type": "post",    "url": "/uploadVideo/",    "title": "Upload Video",    "name": "UploadVideo",    "version": "0.1.0",    "group": "Upload",    "description": "<p>This route will upload a video to a project (and create a new project if an old one is not specified)</p>",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "File",            "optional": false,            "field": "video",            "description": "<p>The video file to analyze. This can have any file extension.</p>"          },          {            "group": "Parameter",            "type": "String",            "optional": true,            "field": "identifier",            "description": "<p>The identifier of the project to update the video of. If no identifier is provided, a new project will be created, and the identifier will be returned in the response.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "project_identifier",            "description": "<p>The project identifier. This will be used to reference the project in all other requests.</p>"          }        ]      }    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "optional": false,            "field": "error_message",            "description": "<p>The error message to display.</p>"          }        ]      }    },    "filename": "app/handlers/uploadVideo.py",    "groupTitle": "Upload"  }]
+[
+  {
+    "type": "post",
+    "url": "/analysis/",
+    "title": "Analysis",
+    "name": "Analysis",
+    "version": "0.1.0",
+    "group": "Analysis",
+    "description": "<p>Calling this route will perform analysis on the video. When the analysis is done, an email will be sent to the project's user. This test consists of running object tracking on the video, and then running safety analysis on the results of the object tracking. When the analysis is complete, the system will produce a safety report for the intersection. (Due to the potentially long duration of testing, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project to test configuration of.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "email",
+            "description": "<p>The email address that should be notified when the analysis is complete.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "status_code",
+            "description": "<p>The API will return a status code of 200 upon success.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/analysis.py",
+    "groupTitle": "Analysis"
+  },
+  {
+    "type": "post",
+    "url": "/objectTracking/",
+    "title": "Object Tracking",
+    "name": "ObjectTracking",
+    "version": "0.1.0",
+    "group": "Analysis",
+    "description": "<p>Calling this route will perform object tracking on the video. When the analysis is done, an email will be sent to the project's user. (Due to the potentially long run duration, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project on which to run object tracking.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "email",
+            "description": "<p>The email address that should be notified when the object tracking is complete.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "status_code",
+            "description": "<p>The API will return a status code of 200 upon success.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/objectTracking.py",
+    "groupTitle": "Analysis"
+  },
+  {
+    "type": "post",
+    "url": "/safetyAnalysis/",
+    "title": "Safety Analysis",
+    "name": "SafetyAnalysis",
+    "version": "0.1.0",
+    "group": "Analysis",
+    "description": "<p>Calling this route will perform safety analysis on a project that object tracking has already been run on. When the analysis is done, an email will be sent to the project's user. (Due to the potentially long run duration, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project on which to run safety analysis.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "email",
+            "description": "<p>The email address that should be notified when the safety analysis is complete</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "status_code",
+            "description": "<p>The API will return a status code of 200 upon success.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display. (Will return unique error message if object tracking has NOT been run on specified project)</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/safetyAnalysis.py",
+    "groupTitle": "Analysis"
+  },
+  {
+    "type": "post",
+    "url": "/configHomography/",
+    "title": "Config Homography",
+    "name": "ConfigHomography",
+    "version": "0.2.0",
+    "group": "Configuration",
+    "description": "<p>Use this route to upload homography data for a project.</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project for which to configure the homography.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": false,
+            "field": "unit_pixel_ratio",
+            "description": "<p>The unit_pixel_ratio of the images (ie. 0.05 meters per pixel).</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "JSON",
+            "optional": false,
+            "field": "aerial_pts",
+            "description": "<p>A JSON array containing the coordinates of point clicks on the aerial image as arrays in the form [x_coord, y_coord]</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "JSON",
+            "optional": false,
+            "field": "camera_pts",
+            "description": "<p>A JSON array containing the coordinates of point clicks on the camera image as arrays in the form [x_coord, y_coord]</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "status_code",
+            "description": "<p>The API will return a status code of 200 upon success.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/configHomography.py",
+    "groupTitle": "Configuration"
+  },
+  {
+    "type": "post",
+    "url": "/config/",
+    "title": "Configure Project",
+    "name": "Configure_Project",
+    "version": "0.1.0",
+    "group": "Configuration",
+    "description": "<p>Calling this route will modify a specified configuration file using values of the provided arguments.</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project whose configuration files are to be modified.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": true,
+            "field": "max_features_per_frame",
+            "description": "<p>This is the maximum number of features to track per frame. If not provided, a value of 1000 will be used. The recommended value for this is 1000 or greater.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": true,
+            "field": "num_displacement_frames",
+            "description": "<p>This parameter determines how long features will be tracked. If not provided, a value of 10 will be used. The recommended value for this is 2-15.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Number",
+            "optional": true,
+            "field": "min_feature_displacement",
+            "description": "<p>This is the displacement needed to track a feature. If not provided, a value of 0.0001 will be used. The recommended value for this is 0.0001-0.1.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": true,
+            "field": "max_iterations_to_persist",
+            "description": "<p>This is the maximum number of iterations that an unmoving feature should persist. If not provided, a value of 200 will be used. The recommended value for this is 10-1000.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": true,
+            "field": "min_feature_frames",
+            "description": "<p>This is the minimum number of frames that a feature must persist in order to be considered a feature. If not provided, a value of 15 will be used. The recommended value for this is 10-25.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Number",
+            "optional": true,
+            "field": "max_connection_distance",
+            "description": "<p>This is the maximum distance that two features can be apart and still be considered part of the same object. If not provided, a value of 1 will be used.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Number",
+            "optional": true,
+            "field": "max_segmentation_distance",
+            "description": "<p>This is the maximum distance that two features that are moving relative to each other can be apart and still be considered part of the same object. If not provided, a value of .7 will be used.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "status_code",
+            "description": "<p>The API will return a status code of 200 upon success.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/config.py",
+    "groupTitle": "Configuration"
+  },
+  {
+    "type": "get",
+    "url": "/defaultConfig/",
+    "title": "Default Configuration",
+    "name": "Default_Configuration",
+    "version": "0.1.0",
+    "group": "Configuration",
+    "description": "<p>Calling this route will return the default values for the configuration files used by the server. This is useful if you want to display the values of the configuration parameters to the user, without hardcoding the values and potentially being incorrect if default values on the server change.</p>",
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "Integer",
+            "optional": false,
+            "field": "max_features_per_frame",
+            "description": "<p>This is the maximum number of features to track per frame.</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Integer",
+            "optional": false,
+            "field": "num_displacement_frames",
+            "description": "<p>This parameter determines how long features will be tracked.</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Number",
+            "optional": false,
+            "field": "min_feature_displacement",
+            "description": "<p>This is the displacement needed to track a feature.</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Integer",
+            "optional": false,
+            "field": "max_iterations_to_persist",
+            "description": "<p>This is the maximum number of iterations that an unmoving feature should persist.</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Integer",
+            "optional": false,
+            "field": "min_feature_frames",
+            "description": "<p>This is the minimum number of frames that a feature must persist in order to be considered a feature.</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Number",
+            "optional": false,
+            "field": "max_connection_distance",
+            "description": "<p>This is the maximum distance that two features can be apart and still be considered part of the same object.</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Number",
+            "optional": false,
+            "field": "max_segmentation_distance",
+            "description": "<p>This is the maximum distance that two features that are moving relative to each other can be apart and still be considered part of the same object.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/defaultConfig.py",
+    "groupTitle": "Configuration"
+  },
+  {
+    "type": "post",
+    "url": "/testConfig/",
+    "title": "Test Configuration",
+    "name": "TestConfig",
+    "version": "0.1.0",
+    "group": "Configuration",
+    "description": "<p>Calling this route will test the video's configuration. This test consists of running object tracking on a small subset of the video, and producing a video showing the results of the tracking. (Due to the potentially long duration of testing, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "test_flag",
+            "description": "<p>Flag to determine whether feature tracking or object tracking will be tested.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project to test configuration of.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": true,
+            "field": "frame_start",
+            "description": "<p>The frame number to start the configuration test at. If no frame_start is provided, the configuration test will start at the beginning of the video.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": true,
+            "field": "num_frames",
+            "description": "<p>The number of frames to analyze. To keep configuration testing short, this parameter must be less than 200. If no num_frames is provided, a default value of 100 will be used.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "status_code",
+            "description": "<p>The API will return a status code of 200 upon success.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/testConfig.py",
+    "groupTitle": "Configuration"
+  },
+  {
+    "type": "post",
+    "url": "/highlightVideo/",
+    "title": "Highlight Video",
+    "name": "HighlightVideo",
+    "version": "0.1.0",
+    "group": "Results",
+    "description": "<p>Calling this route will create a highlight video of dangerous interactions from a specified project. When the video is created, an email will be sent to the project's user. This route requires running object tracking on the video, and then running safety analysis on the results of the object tracking beforehand. (Due to the potentially long duration, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project to create a highlight video for.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Float",
+            "optional": true,
+            "field": "ttc_threshold",
+            "description": "<p>Threshold for determining whether an interaction is dangerous. Default 1.5 seconds.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": true,
+            "field": "vehicle_only",
+            "description": "<p>Flag for specifying only vehicle-vehicle interactions. Default to True.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "status_code",
+            "description": "<p>The API will return a status code of 200 upon success.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/createHighlightVideo.py",
+    "groupTitle": "Results"
+  },
+  {
+    "type": "post",
+    "url": "/makeReport/",
+    "title": "Make Report",
+    "name": "MakeReport",
+    "version": "0.1.0",
+    "group": "Results",
+    "description": "<p>Calling this route will create a safety report for a specified project. When the report is created, an email will be sent to the project's user. This route requires running object tracking on the video, and then running safety analysis on the results of the object tracking beforehand. (Due to the potentially long duration, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project for which to create the report.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "status_code",
+            "description": "<p>The API will return a status code of 200 upon success.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/makeReport.py",
+    "groupTitle": "Results"
+  },
+  {
+    "type": "get",
+    "url": "/retrieveResults/",
+    "title": "Retrieve Results",
+    "name": "RetrieveResults",
+    "version": "0.0.0",
+    "group": "Results",
+    "description": "<p>This route will retrieve any metadata associated with the project. This includes test video files and safety analysis results.</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project to retrieve results from.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "files",
+            "description": "<p>The API will return all metadata since last retrieval as a compressed archive.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/retrieveResults.py",
+    "groupTitle": "Results"
+  },
+  {
+    "type": "post",
+    "url": "/roadUserCounts/",
+    "title": "Road User Counts",
+    "name": "RoadUserCounts",
+    "version": "0.1.0",
+    "group": "Results",
+    "description": "<p>Calling this route will create a road user counts image from a specified project. When the image is created, an email will be sent to the project's user. This route requires running object tracking on the video, and then running safety analysis on the results of the object tracking beforehand. (Due to the potentially long duration, it is infeasible to return the results as a response to the HTTP request. In order to check the status of the testing and view results, see the Status group of messages.)</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project to create road user counts for.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "status_code",
+            "description": "<p>The API will return a status code of 200 upon success.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/roadUserCounts.py",
+    "groupTitle": "Results"
+  },
+  {
+    "type": "post",
+    "url": "/speedDistribution/",
+    "title": "Speed Distribution",
+    "name": "SpeedDistribution",
+    "version": "0.1.0",
+    "group": "Results",
+    "description": "<p>Calling this route will create a graph of the speed distribution from a specified project.</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project to create a speed distribution for.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Integer",
+            "optional": true,
+            "field": "speed_limit",
+            "description": "<p>speed limit of the intersection. Defaults to 25 mph.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Boolean",
+            "optional": true,
+            "field": "vehicle_only",
+            "description": "<p>Flag for specifying only vehicle speeds</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "status_code",
+            "description": "<p>The API will return a status code of 200 upon success.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/createSpeedDistribution.py",
+    "groupTitle": "Results"
+  },
+  {
+    "type": "post",
+    "url": "/status/",
+    "title": "Processing Status",
+    "name": "ProcessingStatus",
+    "version": "0.1.0",
+    "group": "Status",
+    "description": "<p>Calling this route will return the current status of any long-running processing that your project can perform, is performing or has performed. It returns a field for each possible long-running process whose value can be 0, 1 or 2. A status of 0 for a given field means that that type of processing has not been run on this project. A status of 1 means that that type of processing is currently running for this process. A status of 2 means that the type of processing has been completed for this project. You can poll this endpoint in order to know the status of processing so that you may call the next API call, such as returning results or performing subsequent analysis.</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "identifier",
+            "description": "<p>The identifier of the project on which to return status information.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "upload_homography",
+            "description": "<p>The status of homography file uploading.</p>"
+          },
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "configuration_test",
+            "description": "<p>The status of the configuration test.</p>"
+          },
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "object_tracking",
+            "description": "<p>The status of object tracking.</p>"
+          },
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "safety_analysis",
+            "description": "<p>The status of performing safety analysis.</p>"
+          },
+          {
+            "group": "Success 200",
+            "optional": false,
+            "field": "highlight_video",
+            "description": "<p>The status of creating the highlight video.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display. (Will return unique error message if object tracking has NOT been run on specified project)</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/status.py",
+    "groupTitle": "Status"
+  },
+  {
+    "type": "post",
+    "url": "/upload/",
+    "title": "Upload Files",
+    "name": "UploadFiles",
+    "version": "0.1.0",
+    "group": "Upload",
+    "description": "<p>This route will upload files to a project (and create a new project if an old one is not specified). You may provide a project identifier if you would like to update the files from an old project. If you provide a project identifier for an old project, all of the parameters are optional. If you are creating a new project, all parameters are required. This route will always return a dictionary containing the project identifier.</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "email",
+            "description": "<p>The email to notify when analysis is done.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": true,
+            "field": "identifier",
+            "description": "<p>The identifier of the project to update the file of. If no identifier is provided, a new project will be created, and the identifier will be returned in the response.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "File",
+            "optional": false,
+            "field": "homography/aerialpng",
+            "description": "<p>An aerial photo of the intersection.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "File",
+            "optional": false,
+            "field": "homography/camerapng",
+            "description": "<p>A screenshot of the intersection from the video.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "File",
+            "optional": false,
+            "field": "homography/homographytxt",
+            "description": "<p>The homography text file to use.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "File",
+            "optional": false,
+            "field": "project_namecfg",
+            "description": "<p>The project name configuration file.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "File",
+            "optional": false,
+            "field": "trackingcfg",
+            "description": "<p>The tracking configuration file.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "File",
+            "optional": false,
+            "field": "temp/test/test_object/object_trackingcfg",
+            "description": "<p>The object tracking configuration file.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "File",
+            "optional": false,
+            "field": "temp/test/test_feature/feature_trackingcfg",
+            "description": "<p>The feature tracking configuration file.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "File",
+            "optional": false,
+            "field": "video",
+            "description": "<p>The video file to analyze. This can have any file extension.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "String",
+            "optional": false,
+            "field": "project_identifier",
+            "description": "<p>The project identifier. This will be used to reference the project in all other requests.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/upload.py",
+    "groupTitle": "Upload"
+  },
+  {
+    "type": "post",
+    "url": "/uploadVideo/",
+    "title": "Upload Video",
+    "name": "UploadVideo",
+    "version": "0.1.0",
+    "group": "Upload",
+    "description": "<p>This route will upload a video to a project (and create a new project if an old one is not specified)</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "File",
+            "optional": false,
+            "field": "video",
+            "description": "<p>The video file to analyze. This can have any file extension.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": true,
+            "field": "identifier",
+            "description": "<p>The identifier of the project to update the video of. If no identifier is provided, a new project will be created, and the identifier will be returned in the response.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "String",
+            "optional": false,
+            "field": "project_identifier",
+            "description": "<p>The project identifier. This will be used to reference the project in all other requests.</p>"
+          }
+        ]
+      }
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [
+          {
+            "group": "Error 4xx",
+            "optional": false,
+            "field": "error_message",
+            "description": "<p>The error message to display.</p>"
+          }
+        ]
+      }
+    },
+    "filename": "app/handlers/uploadVideo.py",
+    "groupTitle": "Upload"
+  }
+]

--- a/app/static/apidoc/api_project.js
+++ b/app/static/apidoc/api_project.js
@@ -1,1 +1,16 @@
-define({  "name": "SantosCloud API",  "version": "0.1.0",  "description": "The API documentation for the SantosCloud API that performs video and data analysis of traffic intersections.",  "title": "SantosCloud API",  "url": "",  "sampleUrl": false,  "defaultVersion": "0.0.0",  "apidoc": "0.3.0",  "generator": {    "name": "apidoc",    "time": "2017-02-10T22:47:31.741Z",    "url": "http://apidocjs.com",    "version": "0.17.3"  }});
+define({
+  "name": "SantosCloud API",
+  "version": "0.1.0",
+  "description": "The API documentation for the SantosCloud API that performs video and data analysis of traffic intersections.",
+  "title": "SantosCloud API",
+  "url": "",
+  "sampleUrl": false,
+  "defaultVersion": "0.0.0",
+  "apidoc": "0.3.0",
+  "generator": {
+    "name": "apidoc",
+    "time": "2017-02-15T16:53:30.621Z",
+    "url": "http://apidocjs.com",
+    "version": "0.17.5"
+  }
+});

--- a/app/static/apidoc/api_project.json
+++ b/app/static/apidoc/api_project.json
@@ -1,1 +1,16 @@
-{  "name": "SantosCloud API",  "version": "0.1.0",  "description": "The API documentation for the SantosCloud API that performs video and data analysis of traffic intersections.",  "title": "SantosCloud API",  "url": "",  "sampleUrl": false,  "defaultVersion": "0.0.0",  "apidoc": "0.3.0",  "generator": {    "name": "apidoc",    "time": "2017-02-10T22:47:31.741Z",    "url": "http://apidocjs.com",    "version": "0.17.3"  }}
+{
+  "name": "SantosCloud API",
+  "version": "0.1.0",
+  "description": "The API documentation for the SantosCloud API that performs video and data analysis of traffic intersections.",
+  "title": "SantosCloud API",
+  "url": "",
+  "sampleUrl": false,
+  "defaultVersion": "0.0.0",
+  "apidoc": "0.3.0",
+  "generator": {
+    "name": "apidoc",
+    "time": "2017-02-15T16:53:30.621Z",
+    "url": "http://apidocjs.com",
+    "version": "0.17.5"
+  }
+}

--- a/app/traffic_cloud_utils/plotting/visualization.py
+++ b/app/traffic_cloud_utils/plotting/visualization.py
@@ -286,7 +286,7 @@ def vel_histograms(fig, filename, fps, vistype='overall'):
     connection.commit()
     connection.close()
 
-def vel_cdf(filename, fps, speed_limit=25, dir=None, only_vehicle=True):
+def vel_distribution(filename, fps, speed_limit=25, dir=None, only_vehicle=True):
     """
     Arguments
     ---------
@@ -342,18 +342,10 @@ def vel_cdf(filename, fps, speed_limit=25, dir=None, only_vehicle=True):
     kdepdf = EstimatedPdf(obj_vels)
     pr = cdf.PercentileRank(speed_limit)
 
-    thinkplot.PrePlot(1)
     titlestring = "{:0.1f} % of {} are exceeding the {} mph limit".format(
         100 - pr,
         'vehicles' if only_vehicle else 'road users',
         speed_limit)
-    thinkplot.Cdf(cdf)
-    thinkplot.Vlines(speed_limit, 0, 1)
-    thinkplot.Config(title=titlestring, xlabel='Velocity (mph)', ylabel='CDF')
-    if dir is not None:
-        thinkplot.Save(os.path.join(dir, 'velocityCDF'), formats=['jpg'], bbox_inches='tight')
-    else:
-        thinkplot.Show()
 
     thinkplot.PrePlot(1)
     thinkplot.Pdf(kdepdf)
@@ -502,7 +494,7 @@ if __name__ == '__main__':
     parser.add_argument('roadImageFile', nargs='?', metavar='<Image>',
                         help='The name of the image file containing the video still')
     parser.add_argument('--vis-type', dest='vis_type', help='The visualization you wish to generate. ',
-                        choices=['user-chart', 'vel-indiv', 'vel-overall', 'vel-user', 'trajectories', 'vel-overall-cdf'])
+                        choices=['user-chart', 'vel-indiv', 'vel-overall', 'vel-user', 'trajectories', 'vel-overall-distribution'])
 
     args = parser.parse_args()
 
@@ -514,8 +506,8 @@ if __name__ == '__main__':
         vel_histograms(args.db, args.fps, 'overall')
     elif (args.vis_type == 'vel-user'):
         road_user_vels(args.db, args.fps)
-    elif (args.vis_type == 'vel-overall-cdf'):
-        vel_cdf(args.db, args.fps)
+    elif (args.vis_type == 'vel-overall-distribution'):
+        vel_distribution(args.db, args.fps)
     elif (args.vis_type == 'trajectories'):
         road_user_traj(
             args.db, args.fps, args.homographyFile, args.roadImageFile)


### PR DESCRIPTION
Summary:

- We were currently making CDF / PDF distribution visualizations with
  each call of speedCDF.
- Now, we only make the PDF distribution
- Since CDF was removed, I've renamed it more aptly to "Distribution"
  so that the routes, handlers, and methods are no longer a misnomer

