### PR TITLE
Error handling

### DIFF
--- a/app/handlers/analysis.py
+++ b/app/handlers/analysis.py
@@ -55,7 +55,7 @@ class AnalysisHandler(BaseHandler):
     def handler(identifier, email):
         project_path = get_project_path(identifier)
         if not os.path.exists(project_path):
-            StatusHelper.set_status(identifier, Status.Type.OBJECT_TRACKING, Status.Flag.FAILURE)
+            StatusHelper.set_status(identifier, Status.Type.OBJECT_TRACKING, Status.Flag.FAILURE, failure_message='Project directory does not exist.')
             return (500, 'Project directory does not exist. Check your identifier?')
 
         status_code, reason = ObjectTrackingHandler.handler(identifier, email, AnalysisHandler.object_tracking_callback)

--- a/app/handlers/baseHandler.py
+++ b/app/handlers/baseHandler.py
@@ -36,7 +36,7 @@ class BaseHandler(tornado.web.RequestHandler):
         }
 
         if self.error_message != None:
-            error_dict['message'] = self.error_message
+            error_dict['error_message'] = self.error_message
             print("ERROR: "+self.error_message)
 
         if self.settings.get('serve_traceback') and 'exc_info' in kwargs:

--- a/app/handlers/homography.py
+++ b/app/handlers/homography.py
@@ -26,7 +26,7 @@ class HomographyHandler(BaseHandler):
 
     @apiError error_message The error message to display.
     """
-    
+
     """
     @api {get} /homography/ Get Homography
     @apiName GetHomography
@@ -34,7 +34,7 @@ class HomographyHandler(BaseHandler):
     @apiGroup Configuration
     @apiDescription Use this route to get the homography calculated during configuration.
     @apiParam {String} identifier The identifier of the project for which to configure the homography.
-    
+
     @apiSuccess {Integer[][]} The API will return a status code of 200 upon success.
 
     @apiError error_message The error message to display.
@@ -89,12 +89,13 @@ class HomographyHandler(BaseHandler):
                 np.savetxt(\
                     os.path.join(project_dir,'homography','homography.txt'),\
                     homography)
-            except:
-                self.error_messag = "Could not find the homography, check your points and try again"
+            except Exception as e:
+                self.error_message = "Could not find the homography, check your points and try again"
                 StatusHelper.set_status(\
                                         self.identifier,\
                                         Status.Type.HOMOGRAPHY,\
-                                        Status.Flag.FAILURE)
+                                        Status.Flag.FAILURE,
+                                        failure_message='Failed to find homography: '+str(e))
                 raise tornado.web.HTTPError(status_code = 500)
 
         else:
@@ -102,7 +103,8 @@ class HomographyHandler(BaseHandler):
             StatusHelper.set_status(\
                                     self.identifier,\
                                     Status.Type.HOMOGRAPHY,\
-                                    Status.Flag.FAILURE)
+                                    Status.Flag.FAILURE,
+                                    failure_message="Couldn't interpret uploaded points.")
             raise tornado.web.HTTPError(status_code = 500)
 
 

--- a/app/handlers/objectTracking.py
+++ b/app/handlers/objectTracking.py
@@ -77,7 +77,7 @@ class ObjectTrackingHandler(BaseHandler):
         """
         project_path = get_project_path(identifier)
         if not os.path.exists(project_path):
-            StatusHelper.set_status(identifier, Status.Type.OBJECT_TRACKING, Status.Flag.FAILURE)
+            StatusHelper.set_status(identifier, Status.Type.OBJECT_TRACKING, Status.Flag.FAILURE, failure_message='Project directory does not exist.')
             return (500, 'Project directory does not exist. Check your identifier?')
 
         ObjectTrackingThread(identifier, email, callback).start()
@@ -134,8 +134,8 @@ class ObjectTrackingThread(threading.Thread):
                                         "-n", str(batch_size)])
 
         except subprocess.CalledProcessError as excp:
-            StatusHelper.set_status(self.identifier, Status.Type.OBJECT_TRACKING, Status.Flag.FAILURE)
-            return self.callback(500, excp.output, self.identifier, self.email)
+            StatusHelper.set_status(self.identifier, Status.Type.OBJECT_TRACKING, Status.Flag.FAILURE, failure_message='Failed with error: '+str(excp))
+            return self.callback(500, str(excp), self.identifier, self.email)
 
 
         db_make_objtraj(db_path)  # Make our object_trajectories db table

--- a/app/handlers/safetyAnalysis.py
+++ b/app/handlers/safetyAnalysis.py
@@ -66,7 +66,7 @@ class SafetyAnalysisHandler(BaseHandler):
     def handler(identifier, email, callback, prediction_method=None):
         project_path = get_project_path(identifier)
         if not os.path.exists(project_path):
-            StatusHelper.set_status(identifier, Status.Type.SAFETY_ANALYSIS, Status.Flag.FAILURE)
+            StatusHelper.set_status(identifier, Status.Type.SAFETY_ANALYSIS, Status.Flag.FAILURE, failure_message='Project directory does not exist.')
             return (500, 'Project directory does not exist. Check your identifier?')
 
         SafetyAnalysisThread(identifier, email, callback, prediction_method=prediction_method).start()
@@ -102,8 +102,8 @@ class SafetyAnalysisThread(threading.Thread):
 
             subprocess.check_call(["safety-analysis.py", "--cfg", config_path, "--prediction-method", self.prediction_method])
         except subprocess.CalledProcessError as err_msg:
-            StatusHelper.set_status(self.identifier, Status.Type.SAFETY_ANALYSIS, Status.Flag.FAILURE)
-            return self.callback(500, err_msg.output, self.identifier, self.email)
+            StatusHelper.set_status(self.identifier, Status.Type.SAFETY_ANALYSIS, Status.Flag.FAILURE, failure_message='Safety analysis failed with error: '+str(err_msg))
+            return self.callback(500, str(err_msg), self.identifier, self.email)
 
         StatusHelper.set_status(self.identifier, Status.Type.SAFETY_ANALYSIS, Status.Flag.COMPLETE)
         return self.callback(200, "Success", self.identifier, self.email)

--- a/app/handlers/status.py
+++ b/app/handlers/status.py
@@ -25,9 +25,9 @@ class StatusHandler(BaseHandler):
     """
     def get(self):
         identifier = self.find_argument('identifier')
-        status_dict = StatusHelper.get_status_raw(identifier)
+        status_dict = StatusHelper.get_status_raw_with_messages(identifier)
         if status_dict != None:
         	self.write(status_dict)
         else:
-        	# TODO: Error
-        	pass
+            self.error_message = "Could not get project status"
+            raise tornado.web.HTTPError(status_code = 500)

--- a/app/handlers/status.py
+++ b/app/handlers/status.py
@@ -25,7 +25,7 @@ class StatusHandler(BaseHandler):
     """
     def get(self):
         identifier = self.find_argument('identifier')
-        status_dict = StatusHelper.get_status_raw_with_messages(identifier)
+        status_dict = StatusHelper.get_status_raw(identifier)
         if status_dict != None:
         	self.write(status_dict)
         else:

--- a/app/handlers/uploadVideo.py
+++ b/app/handlers/uploadVideo.py
@@ -50,10 +50,12 @@ class UploadVideoHandler(BaseHandler):
                 create_project(self.identifier, video_part)
             else:
                 print "video_part was None"
+                self.error_message = "Error decoding video upload"
                 raise tornado.web.HTTPError(status_code = 500)
 
-        except:
+        except Exception as e:
             print "could not complete streaming of data parts"
+            self.error_message = "Error uploading video: " + str(e)
             raise tornado.web.HTTPError(status_code = 500)
 
         finally:

--- a/app/traffic_cloud_utils/statusHelper.py
+++ b/app/traffic_cloud_utils/statusHelper.py
@@ -42,10 +42,13 @@ class StatusHelper(object):
             update_config_with_sections(config_path, "status", status_type.value, str(status.value))
 
     @staticmethod
-    def set_status(identifier, status_type, val):
+    def set_status(identifier, status_type, val, failure_message=None):
         config_path = get_project_config_path(identifier)
         status = str(val.value)
         update_config_with_sections(config_path, "status", status_type.value, status)
+
+        if failure_message is not None:
+            update_config_with_sections(config_path, "failure_message", status_type.value, message)
 
     @staticmethod
     def get_status(identifier):
@@ -65,9 +68,17 @@ class StatusHelper(object):
     @staticmethod
     def get_status_raw(identifier):
         config_path = get_project_config_path(identifier)
-        (success, value) = get_config_section(config_path, "status")
+        (success, statuses) = get_config_section(config_path, "status")
         if success:
-            return value
+            s, messages = get_config_section(config_path, "failure_message")
+            d = {}
+            for (k,v) in statuses.iteritems():
+                d[k] = { 'status': v }
+                if s and k in messages:
+                    d[k]['failure_message'] = messages[k]
+                elif v == Status.Flag.FAILURE.value:
+                    d[k]['failure_message'] = "Operation failed: "+k
+            return d
         else:
             return None
 
@@ -79,7 +90,7 @@ class StatusHelper(object):
             if status:
                 for (k, v) in status.iteritems():
                     if v == Status.Flag.IN_PROGRESS:
-                        StatusHelper.set_status(identifier, k, Status.Flag.FAILURE)
+                        StatusHelper.set_status(identifier, k, Status.Flag.FAILURE, failure_message='Failed when server died')
             else:
                 print "Error: Could not mark project status failure flags for project {}".format(identifier)
 

--- a/app/traffic_cloud_utils/statusHelper.py
+++ b/app/traffic_cloud_utils/statusHelper.py
@@ -74,7 +74,7 @@ class StatusHelper(object):
             d = {}
             for (k,v) in statuses.iteritems():
                 d[k] = { 'status': v }
-                if s and k in messages:
+                if s and k in messages and int(v) == Status.Flag.FAILURE.value:
                     d[k]['failure_message'] = messages[k]
                 elif v == Status.Flag.FAILURE.value:
                     d[k]['failure_message'] = "Operation failed: "+k

--- a/app/traffic_cloud_utils/statusHelper.py
+++ b/app/traffic_cloud_utils/statusHelper.py
@@ -48,7 +48,7 @@ class StatusHelper(object):
         update_config_with_sections(config_path, "status", status_type.value, status)
 
         if failure_message is not None:
-            update_config_with_sections(config_path, "failure_message", status_type.value, message)
+            update_config_with_sections(config_path, "failure_message", status_type.value, failure_message)
 
     @staticmethod
     def get_status(identifier):


### PR DESCRIPTION
Does three things:

1. Renames the error message return key to `error_message`
2. Fixes some places where we didn't give error messages
3. Creates and stores a failure message for long-running processes if they fail. This is automatically given back at the `/status` endpoint because get_status_raw gets these.

Should be merged at the same time as the corresponding PR in SantosGUI: https://github.com/santosfamilyfoundation/SantosGUI/pull/86