### PR TITLE
Temp highlight video does not load entire DB

### DIFF
--- a/app/traffic_cloud_utils/video.py
+++ b/app/traffic_cloud_utils/video.py
@@ -124,7 +124,7 @@ def create_trajectory_video(video_path, db_filename, homography_path, output_pat
     framerate = get_framerate(video_path)
 
     print('Loading objects, please wait...')
-    objects = loadTrajectoriesFromSqlite(db_filename, video_type, objects_to_label, withFeatures=bounding_boxes)
+    objects = loadTrajectoriesFromSqlite(db_filename, video_type, objectNumbers = objects_to_label, withFeatures=bounding_boxes)
     homography = inv(loadtxt(homography_path))
 
     ret = True

--- a/app/traffic_cloud_utils/video.py
+++ b/app/traffic_cloud_utils/video.py
@@ -124,7 +124,7 @@ def create_trajectory_video(video_path, db_filename, homography_path, output_pat
     framerate = get_framerate(video_path)
 
     print('Loading objects, please wait...')
-    objects = loadTrajectoriesFromSqlite(db_filename, video_type, objectNumbers = objects_to_label, withFeatures=bounding_boxes)
+    objects = loadTrajectoriesFromSqlite(db_filename, video_type, objectNumbers=objects_to_label, withFeatures=bounding_boxes)
     homography = inv(loadtxt(homography_path))
 
     ret = True

--- a/app/traffic_cloud_utils/video.py
+++ b/app/traffic_cloud_utils/video.py
@@ -124,7 +124,7 @@ def create_trajectory_video(video_path, db_filename, homography_path, output_pat
     framerate = get_framerate(video_path)
 
     print('Loading objects, please wait...')
-    objects = loadTrajectoriesFromSqlite(db_filename, video_type, withFeatures=bounding_boxes)
+    objects = loadTrajectoriesFromSqlite(db_filename, video_type, objects_to_label, withFeatures=bounding_boxes)
     homography = inv(loadtxt(homography_path))
 
     ret = True


### PR DESCRIPTION
Summary: By passing in the two interacting object ids to the function that loads in trajectories from the database, we avoid loading the entire database.  This now makes temp highlight video creation faster.

Resolves: #80 

Tested by calling the highlight video route, seeing that len(objects) is 2, and noticing the speed difference for creating temp highlight videos